### PR TITLE
Remove double freeze print on single player freezes

### DIFF
--- a/lua/ulx/modules/sh/cfc_freeze.lua
+++ b/lua/ulx/modules/sh/cfc_freeze.lua
@@ -22,10 +22,11 @@ local function freezeProps( callingPlayer, targetPlayers )
         end
     end
     ulx.fancyLogAdmin( callingPlayer, "#A froze "..entCount.." props owned by #T", targetPlayers )
-    if #targetPlayers > 1 then
-        for ply, num in pairs( entCounts ) do
-            ULib.tsay( ply, ply:Nick() .. " owned " .. num .. " props.", true )
-        end
+    
+    if #targetPlayers <= 1 then return end
+    
+    for ply, num in pairs( entCounts ) do
+        ULib.tsay( ply, ply:Nick() .. " owned " .. num .. " props.", true )
     end
 end
 

--- a/lua/ulx/modules/sh/cfc_freeze.lua
+++ b/lua/ulx/modules/sh/cfc_freeze.lua
@@ -22,8 +22,10 @@ local function freezeProps( callingPlayer, targetPlayers )
         end
     end
     ulx.fancyLogAdmin( callingPlayer, "#A froze "..entCount.." props owned by #T", targetPlayers )
-    for ply, num in pairs( entCounts ) do
-        ULib.tsay( ply, ply:Nick() .. " owned " .. num .. " props.", true )
+    if #targetPlayers > 1 then
+        for ply, num in pairs( entCounts ) do
+            ULib.tsay( ply, ply:Nick() .. " owned " .. num .. " props.", true )
+        end
     end
 end
 


### PR DESCRIPTION
Double print really isnt needed when freezing a single player, adds no information.