### PR TITLE
Auto ban bad convars

### DIFF
--- a/lua/ulx/modules/sh/cfc_checklua.lua
+++ b/lua/ulx/modules/sh/cfc_checklua.lua
@@ -57,15 +57,15 @@ if SERVER then
             print( "Banning " .. tostring( ply ) .. " for having bad convars." )
             PrintTable( badConvars )
 
-            ulx.ban( nil, ply, AUTO_BAN_LENGTH, AUTO_BAN_REASON )
             sendAwarn( ply )
+            ulx.ban( nil, ply, AUTO_BAN_LENGTH, AUTO_BAN_REASON )
         end
     end )
 
     function cmd.checkluaPlayers( callingPlayer, targetPlayers )
         for _, ply in pairs( targetPlayers ) do
             awaitingResponse[ply] = callingPlayer
-            net.Start( "CFC_ULX_StatCheckCL" )
+            net.Start( "CFC_ULX_StatCheck" )
             net.Send( ply )
         end
     end
@@ -103,13 +103,7 @@ if CLIENT then
     end )
 end
 
-local function doCheck( ... )
-    if CLIENT then return end
-
-    return cmd.checkluaPlayers( ... )
-end
-
-local checkluaCommand = ulx.command( CATEGORY_NAME, "ulx checklua", doCheck, "!checklua" )
+local checkluaCommand = ulx.command( CATEGORY_NAME, "ulx checklua", cmd.checkluaPlayers, "!checklua" )
 checkluaCommand:addParam{ type = ULib.cmds.PlayersArg }
 checkluaCommand:defaultAccess( ULib.ACCESS_ADMIN )
 checkluaCommand:help( "Checks target(s) sv_allowcslua, true means they modified their client value." )

--- a/lua/ulx/modules/sh/cfc_checklua.lua
+++ b/lua/ulx/modules/sh/cfc_checklua.lua
@@ -2,40 +2,114 @@ CFCUlxCommands.checklua = CFCUlxCommands.checklua or {}
 local cmd = CFCUlxCommands.checklua
 
 local CATEGORY_NAME = "Utility"
+local AUTO_BAN_LENGTH = ( 60 * 60 ) * 6
+local AUTO_BAN_REASON = "Server/Client mismatch. Please disable any third-party programs that modify your game."
+local CONVARS_TO_CHECK = { "sv_allowcslua" }
 
 if SERVER then
-    util.AddNetworkString( "CFC_ULX_StatCheckCL" )
-    util.AddNetworkString( "CFC_ULX_StatCheckSV" )
-end
+    util.AddNetworkString( "CFC_ULX_StatCheck" )
+    util.AddNetworkString( "CFC_ULX_AutoStatCheck" )
 
-local awaitingResponse = {}
+    local awaitingResponse = {}
 
-net.Receive( "CFC_ULX_StatCheckSV", function( _, ply )
-    if not awaitingResponse[ply] then return end
-    local convar = net.ReadBool()
-    ulx.fancyLogAdmin( awaitingResponse[ply], true, "#T's sv_allowcslua value is " .. tostring( convar ), ply )
+    local function sendAwarn( ply )
+        if not awarn_warnplayer then return end
 
-    awaitingResponse[ply] = nil
-end )
-
-function cmd.checkluaPlayers( callingPlayer, targetPlayers )
-    for _, ply in pairs( targetPlayers ) do
-        awaitingResponse[ply] = callingPlayer
-        net.Start( "CFC_ULX_StatCheckCL" )
-        net.Send( ply )
+        awarn_warnplayer( nil, ply, AUTO_BAN_REASON )
     end
-end
 
-if CLIENT then
-    net.Receive( "CFC_ULX_StatCheckCL", function()
-        local convarBool = GetConVar( "sv_allowcslua" ):GetBool()
-        net.Start( "CFC_ULX_StatCheckSV" )
-        net.WriteBool( convarBool )
-        net.SendToServer()
+    local function receiveConvars( ply )
+        local any = false
+        local badConvars = {}
+
+        for _, convar in pairs( CONVARS_TO_CHECK ) do
+            local convarValue = net.ReadBool()
+
+            if convarValue then
+                any = true
+                badCovnars[convar] = convarValue
+                ulx.fancyLogAdmin( awaitingResponse[ply], true, "#T's " .. convar .. "value is " .. tostring( convarValue ), ply )
+            end
+        end
+
+        return any, badConvars
+    end
+
+    local function unawaitTimerName( steamId )
+        return "CFC_ULX_AutoStatsUnAwait_" .. steamId
+    end
+
+    net.Receive( "CFC_ULX_StatCheck", function( _, ply )
+        if not awaitingResponse[ply] then return end
+        awaitingResponse[ply] = nil
+
+        receiveConvars( ply )
+    end )
+
+    net.Receive( "CFC_ULX_AutoStatCheck", function( _, ply )
+        if not awaitingResponse[ply] then return end
+        awaitingResponse[ply] = nil
+        timer.Remove( unawaitTimerName( ply:GetSteamID() ) )
+
+        local anyConvars, badConvars = receiveConvars( ply )
+
+        if anyConvars then
+            print( "Banning " .. tostring( ply ) .. " for having bad convars." )
+            PrintTable( badConvars )
+
+            ulx.ban( nil, ply, AUTO_BAN_LENGTH, AUTO_BAN_REASON )
+            sendAwarn( ply )
+        end
+    end )
+
+    function cmd.checkluaPlayers( callingPlayer, targetPlayers )
+        for _, ply in pairs( targetPlayers ) do
+            awaitingResponse[ply] = callingPlayer
+            net.Start( "CFC_ULX_StatCheckCL" )
+            net.Send( ply )
+        end
+    end
+
+    gameevent.Listen( "player_connect" )
+    hook.Add( "player_connect", "CFC_ULX_AutoStatsCheckOnConnect", function( data )
+        local steamId = data.networkid
+
+        local ply = player.GetBySteamID( steamId )
+        awaitingResponse[ply] = true
+
+        timer.Create( unawaitTimerName( steamId ), 60 * 15, 1, function()
+            awaitingResponse[ply] = nil
+        end )
     end )
 end
 
-local checkluaCommand = ulx.command( CATEGORY_NAME, "ulx checklua", cmd.checkluaPlayers, "!checklua" )
+if CLIENT then
+    local function respondToQuery( networkString )
+        net.Start( networkString )
+
+        for _, convar in pairs( CONVARS_TO_CHECK ) do
+            net.WriteBool( GetConVar( convar ):GetBool() )
+        end
+
+        net.SendToServer()
+    end
+
+    net.Receive( "CFC_ULX_StatCheck", function()
+        respondToQuery( "CFC_ULX_StatCheck" )
+    end )
+
+    hook.Add( "InitPostEntity", "CFC_ULX_StatsReady", function()
+        respondToQuery( "CFC_ULX_AutoStatCheck" )
+    end )
+end
+
+local function doCheck( ... )
+    if CLIENT then return end
+
+    return cmd.checkluaPlayers( ... )
+end
+
+local checkluaCommand = ulx.command( CATEGORY_NAME, "ulx checklua", doCheck, "!checklua" )
 checkluaCommand:addParam{ type = ULib.cmds.PlayersArg }
 checkluaCommand:defaultAccess( ULib.ACCESS_ADMIN )
 checkluaCommand:help( "Checks target(s) sv_allowcslua, true means they modified their client value." )

--- a/lua/ulx/modules/sh/cfc_checklua.lua
+++ b/lua/ulx/modules/sh/cfc_checklua.lua
@@ -88,7 +88,8 @@ if CLIENT then
         net.Start( networkString )
 
         for _, convar in pairs( CONVARS_TO_CHECK ) do
-            net.WriteBool( GetConVar( convar ):GetBool() )
+            local cvar = GetConVar( convar )
+            net.WriteBool( cvar and cvar:GetBool() or false )
         end
 
         net.SendToServer()


### PR DESCRIPTION
After talking with @Deconkle , it seems like the desired functionality is to automatically ban people for a short period of time if they have any naughty convars.

I also made it easier to add more convars to check for (but only bools, and it assumes `true == naughty`).
I ended up rearranging some of the client/server division too.