### PR TITLE
Fix propify

### DIFF
--- a/lua/ulx/modules/sh/cfc_propify.lua
+++ b/lua/ulx/modules/sh/cfc_propify.lua
@@ -252,6 +252,7 @@ hook.Add( "PlayerUse", "CFC_ULX_PropifyUse", handleUse, HOOK_HIGH )
 
 local function propifyForceTryUse( ply, button )
     if button ~= IN_USE then return end
+    if not ply.ragdoll then return end
 
     timer.Create( "CFC_ULX_PropifyForceTryUse" .. ply:SteamID(), 0.01, 1, function()
         local ent = manualUseTrace( ply )


### PR DESCRIPTION
Propify would call the use hook on every use+ but never actually check if the player was ragdolled thus resulting in errors whenever anyone presses +use. This adds a check to check if ply.ragdoll exists and if it doesn't it stops the function.