### PR TITLE
Add ulx ropecheck

### DIFF
--- a/lua/ulx/modules/sh/cfc_ropecheck.lua
+++ b/lua/ulx/modules/sh/cfc_ropecheck.lua
@@ -37,4 +37,4 @@ end
 
 local ropecheckCommand = ulx.command( CATEGORY_NAME, "ulx ropecheck", cmd.ropecheck, "!ropecheck" )
 ropecheckCommand:defaultAccess( ULib.ACCESS_ADMIN )
-ropecheckCommand:help( "Clear all the weapons currently on the ground." )
+ropecheckCommand:help( "Clear all the ropes currently on the ground." )

--- a/lua/ulx/modules/sh/cfc_ropecheck.lua
+++ b/lua/ulx/modules/sh/cfc_ropecheck.lua
@@ -23,7 +23,7 @@ function cmd.ropecheck( callingPlayer )
         end
     end
     if ropeCount == 0 then
-        ulx.fancyLogAdmin( callingPlayer, true, "#A checked the copecount there are currently, no ropes on the map" )
+        ulx.fancyLogAdmin( callingPlayer, true, "#A checked the ropecount there are currently, no ropes on the map" )
         return
     end
 

--- a/lua/ulx/modules/sh/cfc_ropecheck.lua
+++ b/lua/ulx/modules/sh/cfc_ropecheck.lua
@@ -22,6 +22,7 @@ function cmd.ropecheck( callingPlayer )
             end
         end
     end
+
     if ropeCount == 0 then
         ulx.fancyLogAdmin( callingPlayer, true, "#A checked the ropecount there are currently, no ropes on the map" )
         return

--- a/lua/ulx/modules/sh/cfc_ropecheck.lua
+++ b/lua/ulx/modules/sh/cfc_ropecheck.lua
@@ -1,0 +1,40 @@
+CFCUlxCommands.ropecheck = CFCUlxCommands.ropecheck or {}
+local cmd = CFCUlxCommands.ropecheck
+local CATEGORY_NAME = "Utility"
+local IsValid = IsValid
+
+function cmd.ropecheck( callingPlayer )
+    local ropeCount = {}
+    local totalRopeCount = 0
+    local entities = ents.GetAll()
+    local players = player.GetHumans()
+
+    for _, ply in ipairs( players ) do
+        ropeCount[ply] = 0
+    end
+
+    for _, ent in ipairs( entities ) do
+        if ent:GetClass() == "keyframe_rope" then
+            local owner = ent.CPPIGetOwner and ent:CPPIGetOwner()
+            if owner and ropeCount[owner] then
+                ropeCount[owner] = ropeCount[owner] + 1
+                totalRopeCount = totalRopeCount + 1
+            end
+        end
+    end
+    if ropeCount == 0 then
+        ulx.fancyLogAdmin( callingPlayer, true, "#A checked the copecount there are currently, no ropes on the map" )
+        return
+    end
+
+    for _, ply in pairs( players ) do
+        if not ropeCount[ply] or ropeCount[ply] < 0 then return end
+        callingPlayer:ChatPrint( ply:GetName() .. " owns: " .. ropeCount[ply] .. " ropes." )
+    end
+
+    ulx.fancyLogAdmin( callingPlayer, true, "#A checked the copecount there are currently, " .. totalRopeCount .. " ropes in total on the map" )
+end
+
+local ropecheckCommand = ulx.command( CATEGORY_NAME, "ulx ropecheck", cmd.ropecheck, "!ropecheck" )
+ropecheckCommand:defaultAccess( ULib.ACCESS_ADMIN )
+ropecheckCommand:help( "Clear all the weapons currently on the ground." )


### PR DESCRIPTION
Ulx ropecheck will allow staff members to check the ropes of all the players and see player specific amounts of ropes, currently there's a gap for staffmembers forcing them either to clear all ropes or using e2's / sf's to check ropes.