### PR TITLE
Fix errors when addon isn't present

### DIFF
--- a/lua/ulx/modules/sh/timed_chip_ban.lua
+++ b/lua/ulx/modules/sh/timed_chip_ban.lua
@@ -43,6 +43,7 @@ TimedPunishments.MakeULXCommands( PUNISHMENT, action, inverseAction, CATEGORY_NA
 
 if SERVER then
     local function setupE2()
+        if not WireAddon then return end
         local e2Meta = scripted_ents.GetStored( "gmod_wire_expression2" ).t
         e2Meta._ChipBan_Setup = e2Meta._ChipBan_Setup or e2Meta.Setup
 
@@ -60,6 +61,7 @@ if SERVER then
     end
 
     local function setupStarfall()
+        if not istable( SF ) then return end
         local starfall = scripted_ents.GetStored( "starfall_processor" ).t
         starfall._ChipBan_SetupFiles = starfall._ChipBan_SetupFiles or starfall.SetupFiles
 


### PR DESCRIPTION
[cfc_ulx_commands] addons/cfc_ulx_commands/lua/ulx/modules/sh/timed_chip_ban.lua:63: attempt to index a nil value
  1. setupStarfall - addons/cfc_ulx_commands/lua/ulx/modules/sh/timed_chip_ban.lua:63
   2. unknown - addons/cfc_ulx_commands/lua/ulx/modules/sh/timed_chip_ban.lua:81

