### PR TITLE
Add ulx forcebuddy

### DIFF
--- a/lua/ulx/modules/sh/cfc_forcebuddy.lua
+++ b/lua/ulx/modules/sh/cfc_forcebuddy.lua
@@ -30,7 +30,7 @@ function cmd.forceBuddy( callingPlayer, targetPlayers, reason )
 
     for _, ply in ipairs( targetPlayers ) do
         ply.ForcedBuddies = ply.ForcedBuddies or {}
-        ply.ForcedBuddies[callingPlayer] = true
+        ply.ForcedBuddies[callingSteamID] = true
 
         og_setbuddy( ply, "fpp_setbuddy", { callingID, 1, 1, 1, 1, 1, 1 } )
     end

--- a/lua/ulx/modules/sh/cfc_forcebuddy.lua
+++ b/lua/ulx/modules/sh/cfc_forcebuddy.lua
@@ -15,7 +15,7 @@ if SERVER then
         if not forcedBuddies then return og_setbuddy( ply, command, args ) end
 
         local target = tonumber( args[1] ) and Player( tonumber( args[1] ) )
-        if forcedBuddies[target:SteamID64()] then return end
+        if IsValid( target ) and forcedBuddies[target:SteamID64()] then return end
 
         return og_setbuddy( ply, command, args )
     end

--- a/lua/ulx/modules/sh/cfc_forcebuddy.lua
+++ b/lua/ulx/modules/sh/cfc_forcebuddy.lua
@@ -1,0 +1,44 @@
+CFCUlxCommands.forceBuddy = CFCUlxCommands.forceBuddy or {}
+local cmd = CFCUlxCommands.forceBuddy
+local CATEGORY_NAME = "Utility"
+
+local tonumber = tonumber
+local og_setbuddy
+
+if SERVER then
+    local concommands = concommand.GetTable()
+    concommands._fpp_setbuddy = concommands._fpp_setbuddy or concommands.fpp_setbuddy
+    og_setbuddy = concommands._fpp_setbuddy
+
+    concommands.fpp_setbuddy = function( ply, command, args )
+        local forcedBuddies = ply.ForcedBuddies
+        if not forcedBuddies then return og_setbuddy( ply, command, args ) end
+
+        local target = tonumber( args[1] ) and Player( tonumber( args[1] ) )
+        if forcedBuddies[target] then return end
+
+        return og_setbuddy( ply, command, args )
+    end
+end
+
+function cmd.forceBuddy( callingPlayer, targetPlayers, reason )
+    -- Doesn't work from console
+    if not IsValid( callingPlayer ) then return end
+
+    local callingID = callingPlayer:UserID()
+
+    for _, ply in ipairs( targetPlayers ) do
+        ply.ForcedBuddies = ply.ForcedBuddies or {}
+        ply.ForcedBuddies[callingPlayer] = true
+
+        og_setbuddy( ply, "fpp_setbuddy", { callingID, 1, 1, 1, 1, 1, 1 } )
+    end
+
+    ulx.fancyLogAdmin( callingPlayer, "#A forced #T to grant them prop protection access (#s)", targetPlayers, reason )
+end
+
+local forceBuddyCommand = ulx.command( CATEGORY_NAME, "ulx forcebuddy", cmd.forceBuddy, "!forcebuddy" )
+forceBuddyCommand:addParam{ type = ULib.cmds.PlayersArg }
+forceBuddyCommand:addParam{ type = ULib.cmds.StringArg, hint = "reason" }
+forceBuddyCommand:defaultAccess( ULib.ACCESS_ADMIN )
+forceBuddyCommand:help( "Force the target(s) to add you as a FPP buddy" )


### PR DESCRIPTION
A goal of ours is to not give admins PP permissions by default.

Admins have all of the permissions they need already, PP is unnecessary.


To accomplish this goal, we need to create a way for Admins to force a player to grant them PP access, for the rare cases where it's actually necessary.
We want to maintain transparency, though, so making sure it's a ULX command with a public print is essential.


If admins really need PP perms, they shouldn't have any problem with it printing to everyone's chat.

Also, it only lasts 10 minutes.


Wrapped FPP concommand code: https://github.com/FPtje/Falcos-Prop-protection/blob/master/lua/fpp/server/settings.lua#L786-L797
