### PR TITLE
Return early if ply isn't valid in timer

### DIFF
--- a/lua/ulx/modules/sh/cfc_brazil.lua
+++ b/lua/ulx/modules/sh/cfc_brazil.lua
@@ -132,7 +132,10 @@ local function sendToPos( caller, targets, message, doSlap )
 
             if doSlap then
                 ULib.slap( ply, 0, 700, false )
-                timer.Simple( 0.5, function() ply:SetPos( pos ) end )
+                timer.Simple( 0.5, function()
+                    if not IsValid( ply ) then return end
+                    ply:SetPos( pos )
+                end )
             else
                 ply:SetPos( pos )
             end


### PR DESCRIPTION
Fixes:
```
addons/cfc_ulx_commands/lua/ulx/modules/sh/cfc_brazil.lua:135: Tried to use a NULL entity!
   1.  unknown - [C]:-1
    2.  SetPos - [C]:-1
     3.  unknown - addons/cfc_ulx_commands/lua/ulx/modules/sh/cfc_brazil.lua:135
```