### PR TITLE
Fix punishments longer than 2³² seconds not showing in `!punishments`

### DIFF
--- a/lua/ulib/modules/client/cfc_timed_punishments.lua
+++ b/lua/ulib/modules/client/cfc_timed_punishments.lua
@@ -33,7 +33,7 @@ net.Receive( "CFC_TimedPunishments_Punishments", function()
 
     for _ = 1, count do
         local name = net.ReadString()
-        local expiration = net.ReadUInt( 32 )
+        local expiration = net.ReadDouble()
         punishments[name] = expiration
     end
 

--- a/lua/ulib/modules/timed_punishments.lua
+++ b/lua/ulib/modules/timed_punishments.lua
@@ -70,7 +70,7 @@ function TP.SendPunishments( ply )
 
     for name, expiration in pairs( punishments ) do
         net.WriteString( name )
-        net.WriteUInt( expiration, 32 )
+        net.WriteDouble( expiration )
     end
 
     net.Send( ply )


### PR DESCRIPTION
This fix modifies the net message sending punishment information to the client.
Instead of sending a UInt32, it sends the expiration as a Double (64bit floating point number) which allows a much bigger range of punishments to be shown.
![image](https://github.com/CFC-Servers/cfc_ulx_commands/assets/94928308/2826c338-2542-4baf-a9b4-949bd9efd310)
