### PR TITLE
Set eyeang roll to 0

### DIFF
--- a/lua/ulx/modules/sh/cfc_ball.lua
+++ b/lua/ulx/modules/sh/cfc_ball.lua
@@ -46,6 +46,7 @@ local function unball( ply )
     ply:Spawn()
 
     ply:SetPos( pos )
+    eyeAngles.r = 0
     ply:SetEyeAngles( eyeAngles )
 
     ulx.clearExclusive( ply )

--- a/lua/ulx/modules/sh/cfc_ball.lua
+++ b/lua/ulx/modules/sh/cfc_ball.lua
@@ -36,8 +36,9 @@ end
 local function unball( ply )
     assert( ply:IsValid(), "Player is invalid: " .. tostring( ply ) )
 
-    local eyeAngles = ply:EyeAngles()
     local pos = ply:GetPos()
+    local eyeAngles = ply:EyeAngles()
+    eyeAngles.r = 0
 
     ply:SetParent()
     ply:UnSpectate()
@@ -46,7 +47,6 @@ local function unball( ply )
     ply:Spawn()
 
     ply:SetPos( pos )
-    eyeAngles.r = 0
     ply:SetEyeAngles( eyeAngles )
 
     ulx.clearExclusive( ply )


### PR DESCRIPTION
Eye roll should always be 0

otherwise players view gets set to a misaligned angled view like this

![image](https://github.com/CFC-Servers/cfc_ulx_commands/assets/69946827/8b85a017-8812-4a21-9e12-cada98efdbc7)
