### PR TITLE
Fix stacking warning reasons...

### DIFF
--- a/lua/autorun/server/cfc_auto_warn_on_commands.lua
+++ b/lua/autorun/server/cfc_auto_warn_on_commands.lua
@@ -128,9 +128,9 @@ function AW.CommandWatcher( caller, commandName, args )
         duration = duration and duration * 60
     end
 
+    local warnReason = AW.buildReason( reason, commandName, duration )
     for _, target in ipairs( targets ) do
-        reason = AW.buildReason( reason, commandName, duration )
-        AW.warn( caller, target, reason )
+        AW.warn( caller, target, warnReason )
     end
 end
 


### PR DESCRIPTION
Tries to fix:
```
] ulx timegag * 5 "test"
AWarn: Players in this group can not be warned!
[AWarn] Bot02 was warned by Phatso: test (ulx timegag 5 minutes) (ulx timegag 5 minutes)
[AWarn] Bot03 was warned by Phatso: test (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes)
[AWarn] Bot04 was warned by Phatso: test (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes)
[AWarn] Bot05 was warned by Phatso: test (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes)
[AWarn] Bot06 was warned by Phatso: test (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes)
[AWarn] Bot07 was warned by Phatso: test (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes) (ulx timegag 5 minutes)
```