### PR TITLE
Fix timed punishment startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 Repo for CFC's custom ULX commands (that aren't separate)
 
 
+## Dependencies:
+- [ulx](https://github.com/TeamUlysses/ulx) and [ulib](https://github.com/TeamUlysses/ulib), obviously
+- [gm_logger](https://github.com/CFC-Servers/gm_logger) for timed punishments
+- [gm_playerload](https://github.com/CFC-Servers/gm_playerload) for timed punishments
+- [cfc_notifications](https://github.com/CFC-Servers/cfc_notifications) for `ulx tpa`
+- [Falco's Prop Protection](https://github.com/FPtje/Falcos-Prop-protection) for `ulx forcebuddy`
+- Any CPPI system (such as [FPP](https://github.com/FPtje/Falcos-Prop-protection)) for commands that interact with player-spawned entities, such as `ulx freezeprops`
+- [Wiremod](https://github.com/wiremod/wire) and [StarfallEX](https://github.com/thegrb93/StarfallEx) for `ulx chipban`
+- `ulx pvpban` requires CFC's private pvp addon, and will silently remove itself without it
+
 ## Curse Effect Config:
 A serverside config for curse effects can be made by creating `cfc_ulx_commands/curse/sv_config.json` in the server's `data/` folder.
 Default/example settings can be found [here](/lua/cfc_ulx_commands/curse/sv_config_default.json).

--- a/lua/ulib/modules/timed_punishments.lua
+++ b/lua/ulib/modules/timed_punishments.lua
@@ -103,6 +103,7 @@ hook.Add( "PlayerInitialSpawn", "CFC_TimedPunishments_Check", function( ply )
                 basePunishment.enable( ply )
             else
                 ErrorNoHaltWithStack( "Unknown punishment type: " .. punishment )
+                punishments[punishment] = nil -- Remove unknown punishment (note that pairs() still works when removing values)
             end
         end
 

--- a/lua/ulib/modules/timed_punishments.lua
+++ b/lua/ulib/modules/timed_punishments.lua
@@ -97,13 +97,13 @@ hook.Add( "PlayerInitialSpawn", "CFC_TimedPunishments_Check", function( ply )
         ply.TimedPunishments = punishments
 
         -- Run punishment enable functions
-        for punishment in pairs( punishments ) do
-            local basePunishment = Punishments[punishment]
-            if basePunishment then
-                basePunishment.enable( ply )
+        for punishmentName in pairs( punishments ) do
+            local punishment = Punishments[punishmentName]
+            if punishment then
+                punishment.enable( ply )
             else
-                ErrorNoHaltWithStack( "Unknown punishment type: " .. punishment )
-                punishments[punishment] = nil -- Remove unknown punishment (note that pairs() still works when removing values)
+                ErrorNoHaltWithStack( "Unknown punishment type: " .. punishmentName )
+                punishments[punishmentName] = nil -- Remove unknown punishment (note that pairs() still works when removing values)
             end
         end
 

--- a/lua/ulib/modules/timed_punishments.lua
+++ b/lua/ulib/modules/timed_punishments.lua
@@ -94,6 +94,8 @@ hook.Add( "PlayerInitialSpawn", "CFC_TimedPunishments_Check", function( ply )
         punishments = Data:getActivePunishments( steamID64 )
         if not punishments then return end
 
+        ply.TimedPunishments = punishments
+
         -- Run punishment enable functions
         for punishment in pairs( punishments ) do
             local basePunishment = Punishments[punishment]
@@ -103,8 +105,6 @@ hook.Add( "PlayerInitialSpawn", "CFC_TimedPunishments_Check", function( ply )
                 ErrorNoHaltWithStack( "Unknown punishment type: " .. punishment )
             end
         end
-
-        ply.TimedPunishments = punishments
 
         TP.SendPunishments( ply )
     end )


### PR DESCRIPTION
Fixes a logic inconsistency in how punishments get applied to players as they spawn in, and delays it to ensure net and LocalPlayer() are reliable first.