### PR TITLE
Improve LIDAR

### DIFF
--- a/lua/cfc_ulx_commands/curse/effects/lidar.lua
+++ b/lua/cfc_ulx_commands/curse/effects/lidar.lua
@@ -6,7 +6,7 @@ local VERTS_PER_EXPIRABLE_MESH = 50 * 3
 
 local MESH_EXPIRE_TIME = 2
 local SCAN_INTERVAL = 0.01
-local DOTS_PER_SCAN = 75
+local DOTS_PER_SCAN = 50
 local DOT_SPREAD = 60
 local DOT_SIZE = 3
 local DOT_HITBOX_SIZE = 2


### PR DESCRIPTION
- Makes players more visible by adding 2 bonus scans with a tight spread when a non-bonus scan hits a player
- `curExpirableMesh` also gets expired, so there doesn't end up being a few player dots that linger forever
- Reduces DOTS_PER_SCAN from 75 to 50 to reduce stuttering while scanning for the average computer