### PR TITLE
More curses

### DIFF
--- a/lua/cfc_ulx_commands/curse/effects/chromatic_aberration.lua
+++ b/lua/cfc_ulx_commands/curse/effects/chromatic_aberration.lua
@@ -1,0 +1,73 @@
+local EFFECT_NAME = "ChromaticAberration"
+local SLICES_MIN = 5
+local SLICES_MAX = 10
+local SPREAD_SCALE_MIN = 0.002
+local SPREAD_SCALE_MAX = 0.007
+
+
+local CHANNELS = {
+    Color( 255, 0, 0, 255 ),
+    Color( 0, 255, 0, 255 ),
+    Color( 0, 0, 255, 255 ),
+}
+
+local gameMatVertexColor = CFCUlxCurse.IncludeEffectUtil( "common_materials" ).gameMatVertexColor
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        if SERVER then return end
+
+        local scrW = ScrW()
+        local scrH = ScrH()
+
+        local slices = math.random( SLICES_MIN, SLICES_MAX )
+        local spreadScale = math.Rand( SPREAD_SCALE_MIN, SPREAD_SCALE_MAX )
+
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawHUD", "LBozo", function()
+            render.UpdateScreenEffectTexture()
+
+            cam.Start2D()
+                surface.SetDrawColor( 0, 0, 0, 255 )
+                surface.DrawRect( 0, 0, scrW, scrH )
+
+                surface.SetMaterial( gameMatVertexColor )
+                render.OverrideBlend( true, BLEND_ONE, BLEND_ONE, BLENDFUNC_ADD, BLEND_ZERO, BLEND_ZERO, BLENDFUNC_ADD )
+
+                for _, channel in ipairs( CHANNELS ) do
+                    surface.SetDrawColor( channel )
+
+                    for i = 0, slices - 1 do
+                        local spreadX = math.Rand( -spreadScale, spreadScale )
+
+                        surface.DrawTexturedRectUV( scrW * spreadX, scrH * i / slices, scrW, scrH / slices, 0, i / slices, 1, ( i + 1 ) / slices )
+                    end
+                end
+
+                render.OverrideBlend( false )
+            cam.End2D()
+        end )
+    end,
+
+    onEnd = function()
+        -- Do nothing.
+    end,
+
+    minDuration = nil,
+    maxDuration = nil,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = nil,
+    incompatibileEffects = {
+        "MotionSight",
+    },
+    groups = {
+        "VisualOnly",
+        "ScreenOverlay",
+    },
+    incompatibleGroups = {
+        "HaltRenderScene",
+    },
+} )

--- a/lua/cfc_ulx_commands/curse/effects/color_modify.lua
+++ b/lua/cfc_ulx_commands/curse/effects/color_modify.lua
@@ -57,6 +57,7 @@ CFCUlxCurse.RegisterEffect( {
         "PPColorModify"
     },
     incompatibleGroups = {
+        "HaltRenderScene",
         "PPColorModify",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/color_modify_continuous.lua
+++ b/lua/cfc_ulx_commands/curse/effects/color_modify_continuous.lua
@@ -108,6 +108,7 @@ CFCUlxCurse.RegisterEffect( {
         "PPColorModify"
     },
     incompatibleGroups = {
+        "HaltRenderScene",
         "PPColorModify",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/cyberspace.lua
+++ b/lua/cfc_ulx_commands/curse/effects/cyberspace.lua
@@ -296,7 +296,10 @@ CFCUlxCurse.RegisterEffect( {
     maxDuration = 120,
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
-    incompatibileEffects = {},
+    incompatibileEffects = {
+        "Isometric",
+        "TopDown",
+    },
     groups = {
         "VisualOnly",
         "ScreenOverlay",

--- a/lua/cfc_ulx_commands/curse/effects/cyberspace.lua
+++ b/lua/cfc_ulx_commands/curse/effects/cyberspace.lua
@@ -29,18 +29,14 @@ local wireframeMat
 if CLIENT then
     ignorezMat = CreateMaterial( "cfc_ulx_commands_curse_cyberspace_ignorez", "UnlitGeneric", {
         ["$ignorez"] = 1,
-        --["$color2"] = BACKGROUND_COLOR:ToVector(),
         ["$color2"] = "[" .. tostring( BACKGROUND_COLOR:ToVector() ) .. "]",
     } )
-    --ignorezMat:SetVector( "$color2", BACKGROUND_COLOR:ToVector() )
 
     wireframeMat = CreateMaterial( "cfc_ulx_commands_curse_cyberspace_wireframe", "UnlitGeneric", {
         ["$model"] = 1,
         ["$wireframe"] = 1,
-        --["$color2"] = WIREFRAME_COLOR:ToVector(),
         ["$color2"] = "[" .. tostring( WIREFRAME_COLOR:ToVector() ) .. "]",
     } )
-    --wireframeMat:SetVector( "$color2", WIREFRAME_COLOR:ToVector() )
 end
 
 
@@ -231,7 +227,6 @@ local function drawEnts()
     render.MaterialOverride( wireframeMat )
     render.SetShadowsDisabled( true )
 
-    --for _, ent in ipairs( ents.FindInSphere( EyePos(), SIGHT_RADIUS ) ) do -- Breaks near area portals
     for _, ent in ipairs( ents.GetAll() ) do
         if
             ent.DrawModel and

--- a/lua/cfc_ulx_commands/curse/effects/cyberspace.lua
+++ b/lua/cfc_ulx_commands/curse/effects/cyberspace.lua
@@ -1,0 +1,343 @@
+local EFFECT_NAME = "Cyberspace"
+local EFFECT_NAME_SUPER = "SuperCyberspace" -- Same as Cyberspace, but allows ents to be seen through the world. Still beholdent to the sight radius.
+local BACKGROUND_COLOR = Color( 0, 35, 75 )
+local WIREFRAME_COLOR = Color( 75, 150, 180 )
+local GRID_COLOR = Color( 0, 50, 115 )
+local SIGHT_RADIUS = 500
+local BACKGROUND_RADIUS = SIGHT_RADIUS * 2
+local SPHERE_DETAIL = 50
+local VERT_SCRAPE_TIME_LIMIT = 1 / 60
+local MESH_BUILD_INTERVAL = 0.5
+local GRID_SPACING = 20
+local BAD_CLASSES = {
+    ["class C_BaseFlex"] = true,
+    ["viewmodel"] = true,
+    ["manipulate_bone"] = true,
+    ["physgun_beam"] = true,
+    ["gmod_hands"] = true,
+    ["quad_prop"] = true,
+}
+
+
+local VERT_GROUP_SIZE_LIMIT = 65535 - 3 * 100
+local GRID_LINE_COUNT = math.ceil( SIGHT_RADIUS / GRID_SPACING )
+local VECTOR_DOWN_SIGHT = Vector( 0, 0, -SIGHT_RADIUS )
+
+local ignorezMat
+local wireframeMat
+
+if CLIENT then
+    ignorezMat = CreateMaterial( "cfc_ulx_commands_curse_cyberspace_ignorez", "UnlitGeneric", {
+        ["$ignorez"] = 1,
+        --["$color2"] = BACKGROUND_COLOR:ToVector(),
+        ["$color2"] = "[" .. tostring( BACKGROUND_COLOR:ToVector() ) .. "]",
+    } )
+    --ignorezMat:SetVector( "$color2", BACKGROUND_COLOR:ToVector() )
+
+    wireframeMat = CreateMaterial( "cfc_ulx_commands_curse_cyberspace_wireframe", "UnlitGeneric", {
+        ["$model"] = 1,
+        ["$wireframe"] = 1,
+        --["$color2"] = WIREFRAME_COLOR:ToVector(),
+        ["$color2"] = "[" .. tostring( WIREFRAME_COLOR:ToVector() ) .. "]",
+    } )
+    --wireframeMat:SetVector( "$color2", WIREFRAME_COLOR:ToVector() )
+end
+
+
+local worldMeshes = {}
+local curVertGroup = {}
+local curVertGroupSize = 0
+local vertGroups = { curVertGroup }
+local worldBrushes
+local curBrushInd = 0
+local worldMeshesDone = false
+local worldVertsDone = false
+local nextWorldMeshBuildTime = 0
+
+
+local function nearestMultiple( x, mult )
+    if mult == 0 then return x end
+
+    local positiveMultiple = math.ceil( x / mult ) * mult
+    local negativeMultiple = math.floor( x / mult ) * mult
+
+    if math.abs( x - positiveMultiple ) < math.abs( x - negativeMultiple ) then
+        return positiveMultiple
+    else
+        return negativeMultiple
+    end
+end
+
+local function scrapeWorldVerts()
+    local now = SysTime()
+
+    while SysTime() - now < VERT_SCRAPE_TIME_LIMIT do
+        curBrushInd = curBrushInd + 1
+        local brush = worldBrushes[curBrushInd]
+
+        if not brush then
+            worldVertsDone = true
+            break
+        end
+
+        if curVertGroupSize >= VERT_GROUP_SIZE_LIMIT then
+            curVertGroup = {}
+            curVertGroupSize = 0
+            table.insert( vertGroups, curVertGroup )
+        end
+
+        local verts = brush:GetVertices()
+        local vertCount = #verts
+
+        if vertCount == 3 then
+            for i = 1, 3 do
+                local vert = verts[i]
+
+                curVertGroupSize = curVertGroupSize + 1
+                curVertGroup[curVertGroupSize] = {
+                    pos = vert,
+                }
+            end
+        elseif vertCount > 3 then -- Should be impossible to have a brush with less than three, but for just in case.
+            local firstVert = verts[1]
+            local prevVert = verts[3]
+
+            curVertGroupSize = curVertGroupSize + 1
+            curVertGroup[curVertGroupSize] = {
+                pos = firstVert,
+            }
+
+            local vert2 = verts[2]
+
+            curVertGroupSize = curVertGroupSize + 1
+            curVertGroup[curVertGroupSize] = {
+                pos = vert2,
+            }
+
+            curVertGroupSize = curVertGroupSize + 1
+            curVertGroup[curVertGroupSize] = {
+                pos = prevVert,
+            }
+
+            for i = 4, vertCount do
+                local vert = verts[i]
+
+                curVertGroupSize = curVertGroupSize + 1
+                curVertGroup[curVertGroupSize] = {
+                    pos = firstVert,
+                }
+
+                curVertGroupSize = curVertGroupSize + 1
+                curVertGroup[curVertGroupSize] = {
+                    pos = prevVert,
+                }
+
+                curVertGroupSize = curVertGroupSize + 1
+                curVertGroup[curVertGroupSize] = {
+                    pos = vert,
+                }
+
+                prevVert = vert
+            end
+        end
+    end
+end
+
+local function buildWorldMeshes()
+    local now = CurTime()
+    if now < nextWorldMeshBuildTime then return end
+
+    nextWorldMeshBuildTime = now + MESH_BUILD_INTERVAL
+
+    if #vertGroups == 0 then
+        worldMeshesDone = true
+        return
+    end
+
+    local vertGroup = table.remove( vertGroups, 1 )
+    local mesh = Mesh()
+    mesh:BuildFromTriangles( vertGroup )
+
+    table.insert( worldMeshes, mesh )
+end
+
+local function drawBackgroundSphere()
+    render.SetColorMaterial()
+    render.SetMaterial( ignorezMat )
+    render.DrawSphere( EyePos(), -BACKGROUND_RADIUS, SPHERE_DETAIL, SPHERE_DETAIL, BACKGROUND_COLOR )
+end
+
+local function drawWorld()
+    if not worldMeshesDone then
+        if worldVertsDone then
+            buildWorldMeshes()
+        else
+            scrapeWorldVerts()
+        end
+
+        return
+    end
+
+    render.SetMaterial( wireframeMat )
+
+    for _, mesh in ipairs( worldMeshes ) do
+        mesh:Draw()
+    end
+end
+
+local function drawGridLines()
+    local startPos = EyePos()
+    startPos[1] = nearestMultiple( startPos[1], GRID_SPACING )
+    startPos[2] = nearestMultiple( startPos[2], GRID_SPACING )
+    local endPos = startPos + VECTOR_DOWN_SIGHT
+
+    local tr = util.TraceLine( {
+        start = startPos,
+        endpos = endPos,
+        mask = MASK_SOLID_BRUSHONLY,
+        collisiongroup = COLLISION_GROUP_DEBRIS,
+    } )
+
+    if not tr.HitWorld then return end
+    if not tr.Hit then return end
+
+    local hitPos = tr.HitPos
+    local hitNormal = tr.HitNormal
+    local ang = hitNormal:Angle()
+    local xDir = ang:Right()
+    local yDir = ang:Up()
+
+    local edgeX = hitPos + xDir * SIGHT_RADIUS
+    local edgeXN = hitPos - xDir * SIGHT_RADIUS
+    local edgeY = hitPos + yDir * SIGHT_RADIUS
+    local edgeYN = hitPos - yDir * SIGHT_RADIUS
+
+    render.DrawLine( edgeXN, edgeX, GRID_COLOR, true )
+    render.DrawLine( edgeYN, edgeY, GRID_COLOR, true )
+
+    for i = 1, GRID_LINE_COUNT do
+        local x = i * GRID_SPACING
+        local y = i * GRID_SPACING
+
+        render.DrawLine( edgeXN + y * yDir, edgeX + y * yDir, GRID_COLOR, true )
+        render.DrawLine( edgeYN + x * xDir, edgeY + x * xDir, GRID_COLOR, true )
+        render.DrawLine( edgeXN - y * yDir, edgeX - y * yDir, GRID_COLOR, true )
+        render.DrawLine( edgeYN - x * xDir, edgeY - x * xDir, GRID_COLOR, true )
+    end
+end
+
+local function drawEnts()
+    render.BrushMaterialOverride( wireframeMat )
+    render.MaterialOverride( wireframeMat )
+    render.SetShadowsDisabled( true )
+
+    --for _, ent in ipairs( ents.FindInSphere( EyePos(), SIGHT_RADIUS ) ) do -- Breaks near area portals
+    for _, ent in ipairs( ents.GetAll() ) do
+        if
+            ent.DrawModel and
+            IsValid( ent ) and
+            not BAD_CLASSES[ent:GetClass()] and
+            not ent:IsWeapon() and
+            not ent:IsEffectActive( EF_BONEMERGE ) and
+            not ent:IsEffectActive( EF_NODRAW )
+          then
+            ent:DrawModel()
+        end
+    end
+end
+
+local function drawCoveringSphere()
+    render.SetColorMaterial()
+    render.DrawSphere( EyePos(), -SIGHT_RADIUS, SPHERE_DETAIL, SPHERE_DETAIL, BACKGROUND_COLOR )
+end
+
+local function onCurseStart( effectName, cursedPly )
+    if SERVER then return end
+
+    if not worldBrushes then
+        worldBrushes = game.GetWorld():GetBrushSurfaces()
+    end
+
+    local firstPass = false
+
+    CFCUlxCurse.AddEffectHook( cursedPly, effectName, "RenderScene", "CustomRender", function()
+        firstPass = true
+        render.SetShadowsDisabled( true )
+    end )
+
+    CFCUlxCurse.AddEffectHook( cursedPly, effectName, "PreDrawTranslucentRenderables", "CustomRender", function()
+        return true -- Block normal entity rendering
+    end )
+
+    CFCUlxCurse.AddEffectHook( cursedPly, effectName, "PreDrawOpaqueRenderables", "CustomRender", function( _, skybox, skybox3d )
+        if not firstPass then return true end -- Only draw our stuff once per frame, since this is called multiple times
+        if skybox or skybox3d then return true end
+
+        firstPass = false
+
+        drawBackgroundSphere()
+        drawWorld()
+        drawGridLines()
+        drawEnts()
+        drawCoveringSphere()
+
+        return true -- Block normal entity rendering
+    end )
+end
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        onCurseStart( EFFECT_NAME, cursedPly )
+    end,
+
+    onEnd = function()
+        -- Do nothing.
+    end,
+
+    minDuration = 60,
+    maxDuration = 120,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = nil,
+    incompatibileEffects = {},
+    groups = {
+        "VisualOnly",
+        "ScreenOverlay",
+    },
+    incompatibleGroups = {
+        "ScreenOverlay",
+        "PP",
+    },
+} )
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME_SUPER,
+
+    onStart = function( cursedPly )
+        onCurseStart( EFFECT_NAME_SUPER, cursedPly )
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME_SUPER, "RenderScene", "ESP_Mode", function()
+            render.WorldMaterialOverride( wireframeMat )
+        end )
+    end,
+
+    onEnd = function()
+        -- Do nothing.
+    end,
+
+    minDuration = 60,
+    maxDuration = 120,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = true,
+    incompatibileEffects = {},
+    groups = {
+        "VisualOnly",
+        "ScreenOverlay",
+    },
+    incompatibleGroups = {
+        "ScreenOverlay",
+        "PP",
+    },
+} )

--- a/lua/cfc_ulx_commands/curse/effects/cyberspace.lua
+++ b/lua/cfc_ulx_commands/curse/effects/cyberspace.lua
@@ -298,6 +298,7 @@ CFCUlxCurse.RegisterEffect( {
     excludeFromOnetime = nil,
     incompatibileEffects = {
         "Isometric",
+        "SuperCyberspace",
         "TopDown",
     },
     groups = {
@@ -305,7 +306,6 @@ CFCUlxCurse.RegisterEffect( {
         "ScreenOverlay",
     },
     incompatibleGroups = {
-        "ScreenOverlay",
         "PP",
     },
 } )
@@ -329,13 +329,15 @@ CFCUlxCurse.RegisterEffect( {
     maxDuration = 120,
     onetimeDurationMult = nil,
     excludeFromOnetime = true,
-    incompatibileEffects = {},
+    incompatibileEffects = {
+        "Cyberspace",
+    },
     groups = {
         "VisualOnly",
         "ScreenOverlay",
     },
     incompatibleGroups = {
-        "ScreenOverlay",
+        "HaltRenderScene",
         "PP",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/cyberspace.lua
+++ b/lua/cfc_ulx_commands/curse/effects/cyberspace.lua
@@ -253,10 +253,7 @@ local function onCurseStart( effectName, cursedPly )
         worldBrushes = game.GetWorld():GetBrushSurfaces()
     end
 
-    local firstPass = false
-
     CFCUlxCurse.AddEffectHook( cursedPly, effectName, "RenderScene", "CustomRender", function()
-        firstPass = true
         render.SetShadowsDisabled( true )
     end )
 
@@ -265,7 +262,6 @@ local function onCurseStart( effectName, cursedPly )
     end )
 
     CFCUlxCurse.AddEffectHook( cursedPly, effectName, "PreDrawOpaqueRenderables", "CustomRender", function( _, skybox, skybox3d )
-        if not firstPass then return true end -- Only draw our stuff once per frame, since this is called multiple times
         if skybox or skybox3d then return true end
 
         firstPass = false

--- a/lua/cfc_ulx_commands/curse/effects/drunk_blur.lua
+++ b/lua/cfc_ulx_commands/curse/effects/drunk_blur.lua
@@ -30,6 +30,7 @@ CFCUlxCurse.RegisterEffect( {
     onetimeDurationMult = nil,
     excludeFromOnetime = true,
     incompatibileEffects = {
+        "FilmDevelopment",
         "MotionBlur",
         "MotionSight",
         "Pixelated",

--- a/lua/cfc_ulx_commands/curse/effects/drunk_blur.lua
+++ b/lua/cfc_ulx_commands/curse/effects/drunk_blur.lua
@@ -29,16 +29,13 @@ CFCUlxCurse.RegisterEffect( {
     maxDuration = nil,
     onetimeDurationMult = nil,
     excludeFromOnetime = true,
-    incompatibileEffects = {
-        "FilmDevelopment",
-        "MotionBlur",
-        "MotionSight",
-        "Pixelated",
-    },
+    incompatibileEffects = {},
     groups = {
         "VisualOnly",
+        "MotionBlur",
     },
     incompatibleGroups = {
         "HaltRenderScene",
+        "MotionBlur",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/drunk_blur.lua
+++ b/lua/cfc_ulx_commands/curse/effects/drunk_blur.lua
@@ -1,0 +1,43 @@
+local EFFECT_NAME = "DrunkBlur"
+local ADD_ALPHA = 0.4
+local DRAW_ALPHA = 0.8
+local DELAY = 1
+local PASSES = 10
+
+
+local DELAY_PER_PASS = DELAY / PASSES
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        if SERVER then return end
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "RenderScreenspaceEffects", "Blur", function()
+            for i = 1, PASSES do
+                DrawMotionBlur( ADD_ALPHA, DRAW_ALPHA, DELAY_PER_PASS * i )
+            end
+        end )
+    end,
+
+    onEnd = function()
+        if SERVER then return end
+    end,
+
+    minDuration = nil,
+    maxDuration = nil,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = true,
+    incompatibileEffects = {
+        "MotionBlur",
+        "MotionSight",
+        "Pixelated",
+    },
+    groups = {
+        "VisualOnly",
+    },
+    incompatibleGroups = {
+        "HaltRenderScene",
+    },
+} )

--- a/lua/cfc_ulx_commands/curse/effects/film_development.lua
+++ b/lua/cfc_ulx_commands/curse/effects/film_development.lua
@@ -1,0 +1,80 @@
+local EFFECT_NAME = "FilmDevelopment"
+local ADD_ALPHA = 0.0105
+local DRAW_ALPHA = 1 - ADD_ALPHA
+local DELAY = 0.1
+local PASSES = 10
+
+
+local DELAY_PER_PASS = DELAY / PASSES
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        if SERVER then return end
+
+        local showClearScreenHint = true
+        local clearingScreen = false
+
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "RenderScreenspaceEffects", "Blur", function()
+            if clearingScreen then
+                surface.SetDrawColor( 0, 0, 0, 255 )
+                surface.DrawRect( 0, 0, ScrW(), ScrH() )
+
+                return
+            end
+
+            for i = 1, PASSES do
+                DrawMotionBlur( ADD_ALPHA, DRAW_ALPHA, DELAY_PER_PASS * i )
+            end
+        end )
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "HUDPaint", "DrawHints", function()
+            draw.SimpleText( "Hold E for a second or two", "DermaLarge", ScrW() / 2, ScrH() / 2 + 50, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+            draw.SimpleText( "to clear the screen", "DermaLarge", ScrW() / 2, ScrH() / 2 + 50 + 30, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+        end )
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "KeyPress", "Input", function( _, key )
+            if not IsFirstTimePredicted() then return end
+
+            if key == IN_USE then
+                if showClearScreenHint then
+                    CFCUlxCurse.RemoveEffectHook( cursedPly, EFFECT_NAME, "HUDPaint", "DrawHints" )
+                    showClearScreenHint = false
+                end
+
+                clearingScreen = true
+            end
+        end )
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "KeyRelease", "Input", function( _, key )
+            if not IsFirstTimePredicted() then return end
+
+            if key == IN_USE then
+                clearingScreen = false
+            end
+        end )
+    end,
+
+    onEnd = function()
+        if SERVER then return end
+    end,
+
+    minDuration = 60,
+    maxDuration = 120,
+    onetimeDurationMult = 1,
+    excludeFromOnetime = true,
+    incompatibileEffects = {
+        "MotionBlur",
+        "MotionSight",
+        "Pixelated",
+    },
+    groups = {
+        "VisualOnly",
+    },
+    incompatibleGroups = {
+        "HaltRenderScene",
+    },
+} )

--- a/lua/cfc_ulx_commands/curse/effects/film_development.lua
+++ b/lua/cfc_ulx_commands/curse/effects/film_development.lua
@@ -1,4 +1,5 @@
 local EFFECT_NAME = "FilmDevelopment"
+local EFFECT_NAME_NO_CLEAR = "FilmDevelopmentNoClear"
 local ADD_ALPHA = 0.0105
 local DRAW_ALPHA = 1 - ADD_ALPHA
 local DELAY = 0.1
@@ -8,54 +9,92 @@ local PASSES = 10
 local DELAY_PER_PASS = DELAY / PASSES
 
 
+local function onCurseStart( effectName, cursedPly )
+    if SERVER then return end
+
+    local showClearScreenHint = true
+    local clearingScreen = false
+
+
+    CFCUlxCurse.AddEffectHook( cursedPly, effectName, "RenderScreenspaceEffects", "Blur", function()
+        if clearingScreen then
+            surface.SetDrawColor( 0, 0, 0, 255 )
+            surface.DrawRect( 0, 0, ScrW(), ScrH() )
+
+            return
+        end
+
+        for i = 1, PASSES do
+            DrawMotionBlur( ADD_ALPHA, DRAW_ALPHA, DELAY_PER_PASS * i )
+        end
+    end )
+
+    CFCUlxCurse.AddEffectHook( cursedPly, effectName, "HUDPaint", "DrawHints", function()
+        draw.SimpleText( "Hold E for a second or two", "DermaLarge", ScrW() / 2, ScrH() / 2 + 50, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+        draw.SimpleText( "to clear the screen", "DermaLarge", ScrW() / 2, ScrH() / 2 + 50 + 30, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+    end )
+
+    CFCUlxCurse.AddEffectHook( cursedPly, effectName, "KeyPress", "Input", function( _, key )
+        if not IsFirstTimePredicted() then return end
+
+        if key == IN_USE then
+            if showClearScreenHint then
+                CFCUlxCurse.RemoveEffectHook( cursedPly, effectName, "HUDPaint", "DrawHints" )
+                showClearScreenHint = false
+            end
+
+            clearingScreen = true
+        end
+    end )
+
+    CFCUlxCurse.AddEffectHook( cursedPly, effectName, "KeyRelease", "Input", function( _, key )
+        if not IsFirstTimePredicted() then return end
+
+        if key == IN_USE then
+            clearingScreen = false
+        end
+    end )
+end
+
+
 CFCUlxCurse.RegisterEffect( {
     name = EFFECT_NAME,
 
     onStart = function( cursedPly )
         if SERVER then return end
 
-        local showClearScreenHint = true
-        local clearingScreen = false
+        onCurseStart( EFFECT_NAME, cursedPly )
+    end,
 
+    onEnd = function()
+        if SERVER then return end
+    end,
 
-        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "RenderScreenspaceEffects", "Blur", function()
-            if clearingScreen then
-                surface.SetDrawColor( 0, 0, 0, 255 )
-                surface.DrawRect( 0, 0, ScrW(), ScrH() )
+    minDuration = 60,
+    maxDuration = 120,
+    onetimeDurationMult = 1,
+    excludeFromOnetime = true,
+    incompatibileEffects = {},
+    groups = {
+        "VisualOnly",
+        "MotionBlur",
+    },
+    incompatibleGroups = {
+        "HaltRenderScene",
+        "MotionBlur",
+    },
+} )
 
-                return
-            end
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME_NO_CLEAR,
 
-            for i = 1, PASSES do
-                DrawMotionBlur( ADD_ALPHA, DRAW_ALPHA, DELAY_PER_PASS * i )
-            end
-        end )
+    onStart = function( cursedPly )
+        if SERVER then return end
 
-        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "HUDPaint", "DrawHints", function()
-            draw.SimpleText( "Hold E for a second or two", "DermaLarge", ScrW() / 2, ScrH() / 2 + 50, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
-            draw.SimpleText( "to clear the screen", "DermaLarge", ScrW() / 2, ScrH() / 2 + 50 + 30, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
-        end )
-
-        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "KeyPress", "Input", function( _, key )
-            if not IsFirstTimePredicted() then return end
-
-            if key == IN_USE then
-                if showClearScreenHint then
-                    CFCUlxCurse.RemoveEffectHook( cursedPly, EFFECT_NAME, "HUDPaint", "DrawHints" )
-                    showClearScreenHint = false
-                end
-
-                clearingScreen = true
-            end
-        end )
-
-        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "KeyRelease", "Input", function( _, key )
-            if not IsFirstTimePredicted() then return end
-
-            if key == IN_USE then
-                clearingScreen = false
-            end
-        end )
+        onCurseStart( EFFECT_NAME_NO_CLEAR, cursedPly )
+        CFCUlxCurse.RemoveEffectHook( cursedPly, EFFECT_NAME_NO_CLEAR, "HUDPaint", "DrawHints" )
+        CFCUlxCurse.RemoveEffectHook( cursedPly, EFFECT_NAME_NO_CLEAR, "KeyPress", "Input" )
+        CFCUlxCurse.RemoveEffectHook( cursedPly, EFFECT_NAME_NO_CLEAR, "KeyRelease", "Input" )
     end,
 
     onEnd = function()

--- a/lua/cfc_ulx_commands/curse/effects/film_development.lua
+++ b/lua/cfc_ulx_commands/curse/effects/film_development.lua
@@ -66,15 +66,13 @@ CFCUlxCurse.RegisterEffect( {
     maxDuration = 120,
     onetimeDurationMult = 1,
     excludeFromOnetime = true,
-    incompatibileEffects = {
-        "MotionBlur",
-        "MotionSight",
-        "Pixelated",
-    },
+    incompatibileEffects = {},
     groups = {
         "VisualOnly",
+        "MotionBlur",
     },
     incompatibleGroups = {
         "HaltRenderScene",
+        "MotionBlur",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/isometric.lua
+++ b/lua/cfc_ulx_commands/curse/effects/isometric.lua
@@ -70,7 +70,7 @@ CFCUlxCurse.RegisterEffect( {
                     bottom = scrHH * zoomFrac,
                 },
             }
-        end )
+        end, HOOK_HIGH )
 
         CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "Think", "Zoom", function()
             if orthoDistDir ~= 0 then

--- a/lua/cfc_ulx_commands/curse/effects/isometric.lua
+++ b/lua/cfc_ulx_commands/curse/effects/isometric.lua
@@ -110,6 +110,8 @@ CFCUlxCurse.RegisterEffect( {
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
     incompatibileEffects = {
+        "Cyberspace",
+        "SuperCyberspace",
         "ResidentEvil",
         "TopDown",
     },

--- a/lua/cfc_ulx_commands/curse/effects/lidar.lua
+++ b/lua/cfc_ulx_commands/curse/effects/lidar.lua
@@ -492,7 +492,9 @@ CFCUlxCurse.RegisterEffect( {
     maxDuration = 120,
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
-    incompatibileEffects = {},
+    incompatibileEffects = {
+        "ScreenScroll",
+    },
     groups = {
         "VisualOnly",
         "ScreenOverlay",

--- a/lua/cfc_ulx_commands/curse/effects/lidar.lua
+++ b/lua/cfc_ulx_commands/curse/effects/lidar.lua
@@ -499,8 +499,10 @@ CFCUlxCurse.RegisterEffect( {
     groups = {
         "VisualOnly",
         "ScreenOverlay",
+        "HaltRenderScene",
     },
     incompatibleGroups = {
+        "HaltRenderScene",
         "ScreenOverlay",
         "PP",
     },

--- a/lua/cfc_ulx_commands/curse/effects/lidar.lua
+++ b/lua/cfc_ulx_commands/curse/effects/lidar.lua
@@ -147,15 +147,16 @@ local function addDot( startPos, dir, filter, allowBonusScans )
         color = SLIME_COLOR
     elseif isPlayer then
         color = PLAYER_COLOR
-        putOnExpirableMesh = true
         snd = SCAN_PLAYER_SOUND
+        putOnExpirableMesh = true
     elseif isNPC then
         color = NPC_COLOR
         snd = SCAN_PLAYER_SOUND
+        putOnExpirableMesh = true
     elseif isTheMiniOrb then
         color = THE_MINI_ORB_COLOR
-        putOnExpirableMesh = true
         snd = SCAN_THE_MINI_ORB_SOUND
+        putOnExpirableMesh = true
     else
         color = renderGetSurfaceColor( hitPos - dir * 5, hitPos + dir * 5 )
         color = Color( color.x * 255, color.y * 255, color.z * 255, 255 )

--- a/lua/cfc_ulx_commands/curse/effects/lidar.lua
+++ b/lua/cfc_ulx_commands/curse/effects/lidar.lua
@@ -24,7 +24,7 @@ local BALL_RADIUS = 36 / 2
 
 local SCAN_NORMAL_SOUND = "physics/metal/soda_can_impact_soft1.wav"
 local SCAN_PLAYER_SOUND = "buttons/button17.wav"
-local SCAN_THE_MINI_ORB_COLOR_SOUND = "buttons/button17.wav"
+local SCAN_THE_MINI_ORB_SOUND = "buttons/button17.wav"
 
 local SKY_COLOR = Color( 130, 230, 230, 255 )
 local WATER_COLOR = Color( 50, 100, 225, 255 )
@@ -155,7 +155,7 @@ local function addDot( startPos, dir, filter, allowBonusScans )
     elseif isTheMiniOrb then
         color = THE_MINI_ORB_COLOR
         putOnExpirableMesh = true
-        snd = SCAN_THE_MINI_ORB_COLOR_SOUND
+        snd = SCAN_THE_MINI_ORB_SOUND
     else
         color = renderGetSurfaceColor( hitPos - dir * 5, hitPos + dir * 5 )
         color = Color( color.x * 255, color.y * 255, color.z * 255, 255 )

--- a/lua/cfc_ulx_commands/curse/effects/lidar.lua
+++ b/lua/cfc_ulx_commands/curse/effects/lidar.lua
@@ -24,7 +24,7 @@ local BALL_RADIUS = 36 / 2
 
 local SCAN_NORMAL_SOUND = "physics/metal/soda_can_impact_soft1.wav"
 local SCAN_PLAYER_SOUND = "buttons/button17.wav"
-local SCAN_THE_MINI_ORB_SOUND = "buttons/button17.wav"
+local SCAN_THE_MINI_ORB_SOUND = "physics/metal/metal_sheet_impact_bullet2.wav"
 
 local SKY_COLOR = Color( 130, 230, 230, 255 )
 local WATER_COLOR = Color( 50, 100, 225, 255 )

--- a/lua/cfc_ulx_commands/curse/effects/lidar.lua
+++ b/lua/cfc_ulx_commands/curse/effects/lidar.lua
@@ -494,6 +494,7 @@ CFCUlxCurse.RegisterEffect( {
     excludeFromOnetime = nil,
     incompatibileEffects = {
         "ScreenScroll",
+        "Sunbeams",
     },
     groups = {
         "VisualOnly",

--- a/lua/cfc_ulx_commands/curse/effects/mirror_world.lua
+++ b/lua/cfc_ulx_commands/curse/effects/mirror_world.lua
@@ -9,15 +9,7 @@ CFCUlxCurse.EffectGlobals[EFFECT_NAME_LOWER] = CFCUlxCurse.EffectGlobals[EFFECT_
 local globals = CFCUlxCurse.EffectGlobals[EFFECT_NAME_LOWER]
 
 local vectorMeta = FindMetaTable( "Vector" )
-local gameMat2
-
-
-if CLIENT then
-    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
-        ["$basetexture"] = "_rt_fullframefb",
-        ["$ignorez"] = 1,
-    } )
-end
+local gameMatIgnorez = CFCUlxCurse.IncludeEffectUtil( "common_materials" ).gameMatIgnorez
 
 
 CFCUlxCurse.RegisterEffect( {
@@ -42,7 +34,7 @@ CFCUlxCurse.RegisterEffect( {
             cam.Start2D()
                 render.UpdateScreenEffectTexture()
 
-                surface.SetMaterial( gameMat2 )
+                surface.SetMaterial( gameMatIgnorez )
                 surface.SetDrawColor( 255, 255, 255, 255 )
                 surface.DrawTexturedRectUV( 0, 0, ScrW(), ScrH(), 1, 0, 0, 1 )
             cam.End2D()

--- a/lua/cfc_ulx_commands/curse/effects/mirror_world.lua
+++ b/lua/cfc_ulx_commands/curse/effects/mirror_world.lua
@@ -76,10 +76,7 @@ CFCUlxCurse.RegisterEffect( {
     maxDuration = 120,
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
-    incompatibileEffects = {
-        "ScreenMirror",
-        "ScreenScroll",
-    },
+    incompatibileEffects = {},
     groups = {
         "ScreenOverlay",
         "Input",
@@ -87,7 +84,7 @@ CFCUlxCurse.RegisterEffect( {
         "AD",
     },
     incompatibleGroups = {
-        "ScreenOverlay",
+        "HaltRenderScene",
         "ViewAngles",
         "AD",
     },

--- a/lua/cfc_ulx_commands/curse/effects/model_shuffle.lua
+++ b/lua/cfc_ulx_commands/curse/effects/model_shuffle.lua
@@ -1,0 +1,153 @@
+local EFFECT_NAME = "ModelShuffle"
+local SHUFFLE_INTERVAL = 0.1
+local SHUFFLE_CHANCE_MIN = 0.003
+local SHUFFLE_CHANCE_MAX = 0.05
+local SHUFFLE_CHANCE_EASE = math.ease.InQuart
+local ALLOWED_CLASSES = { -- Only apply to some classes because there's who knows how many that error when their model is messed with.
+    -- For instance, changing a prop_door_rotating results in render errors stating the following:
+        -- ERROR:  Can't draw studio model models/dav0r/hoverball.mdl because CBaseDoor is not derived from C_BaseAnimating
+
+    ["prop_physics"] = true,
+    ["prop_physics_multiplayer"] = true,
+    ["player"] = true,
+    ["starfall_processor"] = true,
+    ["starfall_component"] = true,
+    ["gmod_wire_gate"] = true,
+    ["gmod_wire_expression_2"] = true,
+    ["acf_ammo"] = true,
+    ["gmod_wire_hologram"] = true,
+}
+
+
+-- Create global table
+local EFFECT_NAME_LOWER = string.lower( EFFECT_NAME )
+CFCUlxCurse.EffectGlobals[EFFECT_NAME_LOWER] = CFCUlxCurse.EffectGlobals[EFFECT_NAME_LOWER] or {}
+local globals = CFCUlxCurse.EffectGlobals[EFFECT_NAME_LOWER]
+
+globals.MODELS = globals.MODELS or {}
+globals.MODEL_LOOKUP = globals.MODEL_LOOKUP or {}
+
+local MODELS = globals.MODELS
+local MODEL_LOOKUP = globals.MODEL_LOOKUP
+
+local ogModelsPerEnt = {}
+
+
+-- Also returns true/false whether the model is invalid (doesn't check actual util.IsValidModel())
+local function trackNewModel( model )
+    if not model or type( model ) ~= "string" then return false end
+    if model == "" then return false end
+
+    if MODEL_LOOKUP[model] then return true end
+    if model == "error.mdl" then return true end -- Allow error.mdl to be used, but don't track it.
+
+    table.insert( MODELS, model )
+    MODEL_LOOKUP[model] = true
+
+    return true
+end
+
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        if SERVER then return end
+
+        local entityMeta = FindMetaTable( "Entity" )
+        local shuffleChance = Lerp( SHUFFLE_CHANCE_EASE( math.Rand( 0, 1 ) ), SHUFFLE_CHANCE_MIN, SHUFFLE_CHANCE_MAX )
+
+        -- Wrap :SetModel() to track more models and revert ents correctly if their model is changed after creation.
+        globals.Entity_SetModel = globals.Entity_SetModel or entityMeta.SetModel
+        local _SetModel = globals.Entity_SetModel
+        function entityMeta:SetModel( model )
+            if not trackNewModel( model ) then return end
+
+            ogModelsPerEnt[self] = model
+
+            return _SetModel( self, model )
+        end
+
+        -- Wrap :GetModel() to return the original model so that we don't break addons or e2/sf scripts that check models on client
+        globals.Entity_GetModel = globals.Entity_GetModel or entityMeta.GetModel
+        local _GetModel = globals.Entity_GetModel
+        function entityMeta:GetModel()
+            return ogModelsPerEnt[self] or _GetModel( self )
+        end
+
+
+        local function tryShuffleModel( ent )
+            if not IsValid( ent ) then return end
+            if not ent.SetModel then return end
+            if not ALLOWED_CLASSES[ent:GetClass()] and not ent:IsWeapon() and not ent:IsNPC() then return end
+
+            if not ogModelsPerEnt[ent] then
+                local model = _GetModel( ent )
+
+                trackNewModel( model )
+                ogModelsPerEnt[ent] = model
+            end
+
+            if SHUFFLE_CHANCE ~= 1 and math.Rand( 0, 1 ) >= shuffleChance then return end
+
+            local model = MODELS[math.random( 1, #MODELS )]
+
+            if ent:IsPlayer() or ent:IsNPC() then
+                local isMapModel = string.StartsWith( model, "*" )
+
+                if isMapModel then return end -- Otherwise spams 'Attached [weapon model name] (mod_studio) to *[number]'
+            end
+
+            _SetModel( ent, model )
+        end
+
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "OnEntityCreated", "TrackModels", function( ent )
+            timer.Simple( 0, function() -- In case the model is set directly after creation, for whatever reason
+                if not IsValid( ent ) then return end
+                if not ent.GetModel then return end
+
+                trackNewModel( _GetModel( ent ) )
+            end )
+        end )
+
+        CFCUlxCurse.CreateEffectTimer( cursedPly, EFFECT_NAME, "ShuffleModels", SHUFFLE_INTERVAL, 0, function()
+            for _, ent in ipairs( ents.GetAll() ) do
+                tryShuffleModel( ent )
+            end
+        end )
+    end,
+
+    onEnd = function()
+        if SERVER then return end
+
+        local entityMeta = FindMetaTable( "Entity" )
+        local _SetModel = globals.Entity_SetModel
+
+        for ent, model in pairs( ogModelsPerEnt ) do
+            if IsValid( ent ) then
+                _SetModel( ent, model )
+            end
+
+            ogModelsPerEnt[ent] = nil
+        end
+
+        entityMeta.SetModel = globals.Entity_SetModel
+        entityMeta.GetModel = globals.Entity_GetModel
+    end,
+
+    minDuration = nil,
+    maxDuration = nil,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = true,
+    incompatibileEffects = {},
+    groups = {
+        "Wrap:Entity:SetModel()",
+        "Wrap:Entity:GetModel()",
+    },
+    incompatibleGroups = {
+        "Wrap:Entity:SetModel()",
+        "Wrap:Entity:GetModel()",
+    },
+} )

--- a/lua/cfc_ulx_commands/curse/effects/motion_blur.lua
+++ b/lua/cfc_ulx_commands/curse/effects/motion_blur.lua
@@ -1,0 +1,43 @@
+local EFFECT_NAME = "MotionBlur"
+local ADD_ALPHA = 0.4
+local DRAW_ALPHA = 0.8
+local DELAY = 0.04
+local PASSES = 7
+
+
+local DELAY_PER_PASS = DELAY / PASSES
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        if SERVER then return end
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "RenderScreenspaceEffects", "Blur", function()
+            for i = 1, PASSES do
+                DrawMotionBlur( ADD_ALPHA, DRAW_ALPHA, DELAY_PER_PASS * i )
+            end
+        end )
+    end,
+
+    onEnd = function()
+        if SERVER then return end
+    end,
+
+    minDuration = nil,
+    maxDuration = nil,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = true,
+    incompatibileEffects = {
+        "DrunkBlur",
+        "MotionSight",
+        "Pixelated",
+    },
+    groups = {
+        "VisualOnly",
+    },
+    incompatibleGroups = {
+        "HaltRenderScene",
+    },
+} )

--- a/lua/cfc_ulx_commands/curse/effects/motion_blur.lua
+++ b/lua/cfc_ulx_commands/curse/effects/motion_blur.lua
@@ -29,16 +29,13 @@ CFCUlxCurse.RegisterEffect( {
     maxDuration = nil,
     onetimeDurationMult = nil,
     excludeFromOnetime = true,
-    incompatibileEffects = {
-        "DrunkBlur",
-        "FilmDevelopment",
-        "MotionSight",
-        "Pixelated",
-    },
+    incompatibileEffects = {},
     groups = {
         "VisualOnly",
+        "MotionBlur",
     },
     incompatibleGroups = {
         "HaltRenderScene",
+        "MotionBlur",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/motion_blur.lua
+++ b/lua/cfc_ulx_commands/curse/effects/motion_blur.lua
@@ -31,6 +31,7 @@ CFCUlxCurse.RegisterEffect( {
     excludeFromOnetime = true,
     incompatibileEffects = {
         "DrunkBlur",
+        "FilmDevelopment",
         "MotionSight",
         "Pixelated",
     },

--- a/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
+++ b/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
@@ -49,7 +49,7 @@ CFCUlxCurse.RegisterEffect( {
             } )
         end
 
-        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawViewModels", "FlipTheScreen", function()
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawViewModels", "SubtractiveOverlay", function()
             cam.Start2D()
                 surface.SetDrawColor( 255, 255, 255, 255 )
 
@@ -75,7 +75,7 @@ CFCUlxCurse.RegisterEffect( {
             cam.End2D()
         end )
 
-        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "RenderScene", "FlipTheScreen", function()
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "RenderScene", "CaptureTheScreen", function()
             local now = CurTime()
             if now < nextCaptureTime then return end
 

--- a/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
+++ b/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
@@ -106,6 +106,8 @@ CFCUlxCurse.RegisterEffect( {
     incompatibileEffects = {
         "ColorModify",
         "ColorModifyContinuous",
+        "ScreenMirror",
+        "ScreenScroll",
         "ScreenShuffle",
     },
     groups = {
@@ -116,5 +118,6 @@ CFCUlxCurse.RegisterEffect( {
     incompatibleGroups = {
         "ScreenOverlay",
         "Wrap:Halo.Add",
+        "HaltRenderScene",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
+++ b/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
@@ -7,19 +7,11 @@ local EFFECT_NAME_LOWER = string.lower( EFFECT_NAME )
 CFCUlxCurse.EffectGlobals[EFFECT_NAME_LOWER] = CFCUlxCurse.EffectGlobals[EFFECT_NAME_LOWER] or {}
 local globals = CFCUlxCurse.EffectGlobals[EFFECT_NAME_LOWER]
 
-local gameMat2
+local gameMatIgnorez = CFCUlxCurse.IncludeEffectUtil( "common_materials" ).gameMatIgnorez
 local motionSightRT1
 local motionSightRT2
 local motionSightMat1
 local motionSightMat2
-
-
-if CLIENT then
-    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
-        ["$basetexture"] = "_rt_fullframefb",
-        ["$ignorez"] = 1,
-    } )
-end
 
 
 CFCUlxCurse.RegisterEffect( {
@@ -54,11 +46,11 @@ CFCUlxCurse.RegisterEffect( {
                 surface.SetDrawColor( 255, 255, 255, 255 )
 
                 -- Draw the current screen to the second RT so that it receives the same aliasing/bluring as the first RT.
-                -- This fixes single-pixel differences that would show up if we just used RT1 and gameMat2.
+                -- This fixes single-pixel differences that would show up if we just used RT1 and gameMatIgnorez.
                 render.UpdateScreenEffectTexture()
 
                 render.PushRenderTarget( motionSightRT2 )
-                    surface.SetMaterial( gameMat2 )
+                    surface.SetMaterial( gameMatIgnorez )
                     surface.DrawTexturedRect( 0, 0, ScrW(), ScrH() )
                 render.PopRenderTarget()
 
@@ -85,7 +77,7 @@ CFCUlxCurse.RegisterEffect( {
             cam.Start2D()
             render.PushRenderTarget( motionSightRT1 )
                 surface.SetDrawColor( 255, 255, 255, 255 )
-                surface.SetMaterial( gameMat2 )
+                surface.SetMaterial( gameMatIgnorez )
                 surface.DrawTexturedRect( 0, 0, ScrW(), ScrH() )
                 render.OverrideBlend( false )
             render.PopRenderTarget()

--- a/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
+++ b/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
@@ -106,6 +106,8 @@ CFCUlxCurse.RegisterEffect( {
     incompatibileEffects = {
         "ColorModify",
         "ColorModifyContinuous",
+        "DrunkBlur",
+        "MotionBlur",
         "ScreenMirror",
         "ScreenScroll",
         "ScreenShuffle",

--- a/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
+++ b/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
@@ -107,6 +107,7 @@ CFCUlxCurse.RegisterEffect( {
         "ColorModify",
         "ColorModifyContinuous",
         "DrunkBlur",
+        "FilmDevelopment",
         "MotionBlur",
         "ScreenMirror",
         "ScreenScroll",

--- a/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
+++ b/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
@@ -122,5 +122,6 @@ CFCUlxCurse.RegisterEffect( {
         "ScreenOverlay",
         "Wrap:Halo.Add",
         "HaltRenderScene",
+        "MotionBlur",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
+++ b/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
@@ -106,6 +106,7 @@ CFCUlxCurse.RegisterEffect( {
     incompatibileEffects = {
         "ColorModify",
         "ColorModifyContinuous",
+        "ScreenShuffle",
     },
     groups = {
         "VisualOnly",

--- a/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
+++ b/lua/cfc_ulx_commands/curse/effects/motion_sight.lua
@@ -96,6 +96,7 @@ CFCUlxCurse.RegisterEffect( {
     onetimeDurationMult = nil,
     excludeFromOnetime = true,
     incompatibileEffects = {
+        "ChromaticAberration",
         "ColorModify",
         "ColorModifyContinuous",
         "DrunkBlur",

--- a/lua/cfc_ulx_commands/curse/effects/pixelated.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated.lua
@@ -70,6 +70,7 @@ CFCUlxCurse.RegisterEffect( {
     excludeFromOnetime = nil,
     incompatibileEffects = {
         "DrunkBlur",
+        "FilmDevelopment",
         "MotionBlur",
         "PixelatedEnts",
     },

--- a/lua/cfc_ulx_commands/curse/effects/pixelated.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated.lua
@@ -45,7 +45,7 @@ CFCUlxCurse.RegisterEffect( {
 
         CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawHUD", "Pixelate", function()
             cam.Start2D()
-                surface.SetMaterial( pixelMat, 0, 0, ScrW(), ScrH() )
+                surface.SetMaterial( pixelMat )
                 surface.SetDrawColor( 255, 255, 255, 255 )
 
                 render.PushFilterMag( TEXFILTER.POINT )

--- a/lua/cfc_ulx_commands/curse/effects/pixelated.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated.lua
@@ -68,7 +68,9 @@ CFCUlxCurse.RegisterEffect( {
     maxDuration = 120,
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
-    incompatibileEffects = {},
+    incompatibileEffects = {
+        "ScreenScroll",
+    },
     groups = {
         "VisualOnly",
         "ScreenOverlay",

--- a/lua/cfc_ulx_commands/curse/effects/pixelated.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated.lua
@@ -69,14 +69,14 @@ CFCUlxCurse.RegisterEffect( {
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
     incompatibileEffects = {
-        "ScreenScroll",
+        "PixelatedEnts",
     },
     groups = {
         "VisualOnly",
         "ScreenOverlay",
     },
     incompatibleGroups = {
-        "ScreenOverlay",
+        "HaltRenderScene",
         "PP",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/pixelated.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated.lua
@@ -69,6 +69,8 @@ CFCUlxCurse.RegisterEffect( {
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
     incompatibileEffects = {
+        "DrunkBlur",
+        "MotionBlur",
         "PixelatedEnts",
     },
     groups = {

--- a/lua/cfc_ulx_commands/curse/effects/pixelated.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated.lua
@@ -36,7 +36,7 @@ CFCUlxCurse.RegisterEffect( {
             render.UpdateScreenEffectTexture()
 
             cam.Start2D()
-            render.SetRenderTarget( pixelRT )
+            render.PushRenderTarget( pixelRT, 0, 0, ScrW(), ScrH() )
                 render.Clear( 0, 0, 0, 255, true, true )
                 surface.SetMaterial( gameMat2 )
                 surface.SetDrawColor( 255, 255, 255, 255 )
@@ -44,13 +44,13 @@ CFCUlxCurse.RegisterEffect( {
                 render.PushFilterMin( TEXFILTER.POINT )
                 surface.DrawTexturedRectUV( 0, 0, ScrW() * compressionMult, ScrH() * compressionMult, 0, 0, 1, 1 )
                 render.PopFilterMin()
-            render.SetRenderTarget()
+            render.PopRenderTarget()
             cam.End2D()
         end )
 
         CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawHUD", "Pixelate", function()
             cam.Start2D()
-                surface.SetMaterial( pixelMat )
+                surface.SetMaterial( pixelMat, 0, 0, ScrW(), ScrH() )
                 surface.SetDrawColor( 255, 255, 255, 255 )
 
                 render.PushFilterMag( TEXFILTER.POINT )

--- a/lua/cfc_ulx_commands/curse/effects/pixelated.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated.lua
@@ -1,0 +1,80 @@
+local EFFECT_NAME = "Pixelated"
+local COMPRESSION_LEVEL_MIN = 2
+local COMPRESSION_LEVEL_MAX = 10
+local RT_SIZE = 1024
+
+
+local gameMat2
+local pixelRT
+local pixelMat
+
+if CLIENT then
+    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
+        ["$basetexture"] = "_rt_fullframefb",
+        ["$ignorez"] = 1,
+    } )
+
+    pixelRT = GetRenderTarget( "cfc_ulx_commands_curse_pixelated_rt", RT_SIZE, RT_SIZE )
+
+    pixelMat = CreateMaterial( "cfc_ulx_commands_curse_pixelated", "UnlitGeneric", {
+        ["$basetexture"] = pixelRT:GetName(),
+        ["$ignorez"] = 1,
+    } )
+end
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        if SERVER then return end
+
+        local compressionMult = 1 / math.random( COMPRESSION_LEVEL_MIN, COMPRESSION_LEVEL_MAX )
+
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawEffects", "Pixelate", function()
+            render.UpdateScreenEffectTexture()
+
+            cam.Start2D()
+            render.SetRenderTarget( pixelRT )
+                render.Clear( 0, 0, 0, 255, true, true )
+                surface.SetMaterial( gameMat2 )
+                surface.SetDrawColor( 255, 255, 255, 255 )
+
+                render.PushFilterMin( TEXFILTER.POINT )
+                surface.DrawTexturedRectUV( 0, 0, ScrW() * compressionMult, ScrH() * compressionMult, 0, 0, 1, 1 )
+                render.PopFilterMin()
+            render.SetRenderTarget()
+            cam.End2D()
+        end )
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawHUD", "Pixelate", function()
+            cam.Start2D()
+                surface.SetMaterial( pixelMat )
+                surface.SetDrawColor( 255, 255, 255, 255 )
+
+                render.PushFilterMag( TEXFILTER.POINT )
+                surface.DrawTexturedRectUV( 0, 0, ScrW(), ScrH(), 0, 0, compressionMult, compressionMult )
+                render.PopFilterMag()
+            cam.End2D()
+        end )
+    end,
+
+    onEnd = function()
+        -- Do nothing.
+    end,
+
+    minDuration = 60,
+    maxDuration = 120,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = nil,
+    incompatibileEffects = {},
+    groups = {
+        "VisualOnly",
+        "ScreenOverlay",
+    },
+    incompatibleGroups = {
+        "ScreenOverlay",
+        "PP",
+    },
+} )

--- a/lua/cfc_ulx_commands/curse/effects/pixelated.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated.lua
@@ -4,16 +4,11 @@ local COMPRESSION_LEVEL_MAX = 10
 local RT_SIZE = 1024
 
 
-local gameMat2
+local gameMatIgnorez = CFCUlxCurse.IncludeEffectUtil( "common_materials" ).gameMatIgnorez
 local pixelRT
 local pixelMat
 
 if CLIENT then
-    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
-        ["$basetexture"] = "_rt_fullframefb",
-        ["$ignorez"] = 1,
-    } )
-
     pixelRT = GetRenderTarget( "cfc_ulx_commands_curse_pixelated_rt", RT_SIZE, RT_SIZE )
 
     pixelMat = CreateMaterial( "cfc_ulx_commands_curse_pixelated", "UnlitGeneric", {
@@ -38,7 +33,7 @@ CFCUlxCurse.RegisterEffect( {
             cam.Start2D()
             render.PushRenderTarget( pixelRT, 0, 0, ScrW(), ScrH() )
                 render.Clear( 0, 0, 0, 255, true, true )
-                surface.SetMaterial( gameMat2 )
+                surface.SetMaterial( gameMatIgnorez )
                 surface.SetDrawColor( 255, 255, 255, 255 )
 
                 render.PushFilterMin( TEXFILTER.POINT )

--- a/lua/cfc_ulx_commands/curse/effects/pixelated.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated.lua
@@ -69,9 +69,6 @@ CFCUlxCurse.RegisterEffect( {
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
     incompatibileEffects = {
-        "DrunkBlur",
-        "FilmDevelopment",
-        "MotionBlur",
         "PixelatedEnts",
     },
     groups = {
@@ -80,6 +77,7 @@ CFCUlxCurse.RegisterEffect( {
     },
     incompatibleGroups = {
         "HaltRenderScene",
+        "MotionBlur",
         "PP",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/pixelated_ents.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated_ents.lua
@@ -1,0 +1,122 @@
+local EFFECT_NAME = "PixelatedEnts"
+local COMPRESSION_LEVEL_MIN = 2
+local COMPRESSION_LEVEL_MAX = 10
+local RT_SIZE = 1024
+local BAD_CLASSES = {
+    ["class C_BaseFlex"] = true,
+    ["viewmodel"] = true,
+    ["manipulate_bone"] = true,
+    ["physgun_beam"] = true,
+    ["gmod_hands"] = true,
+    ["quad_prop"] = true,
+}
+
+
+local gameMat2
+local pixelRT
+local pixelMat
+
+if CLIENT then
+    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
+        ["$basetexture"] = "_rt_fullframefb",
+        ["$ignorez"] = 1,
+    } )
+
+    pixelRT = GetRenderTarget( "cfc_ulx_commands_curse_pixelated_ents_rt", RT_SIZE, RT_SIZE )
+
+    pixelMat = CreateMaterial( "cfc_ulx_commands_curse_pixelated_ents", "UnlitGeneric", {
+        ["$basetexture"] = pixelRT:GetName(),
+        ["$ignorez"] = 1,
+    } )
+end
+
+
+local function resetStencil()
+    render.SetStencilWriteMask( 0xFF )
+    render.SetStencilTestMask( 0xFF )
+    render.SetStencilReferenceValue( 0 )
+    render.SetStencilCompareFunction( STENCIL_ALWAYS )
+    render.SetStencilPassOperation( STENCIL_KEEP )
+    render.SetStencilFailOperation( STENCIL_KEEP )
+    render.SetStencilZFailOperation( STENCIL_KEEP )
+    render.ClearStencil()
+end
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        if SERVER then return end
+
+        local compressionMult = 1 / math.random( COMPRESSION_LEVEL_MIN, COMPRESSION_LEVEL_MAX )
+
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawEffects", "Pixelate", function()
+            -- Get a pixelated copy of the 3D scene.
+            render.UpdateScreenEffectTexture()
+
+            cam.Start2D()
+            render.SetRenderTarget( pixelRT )
+                render.Clear( 0, 0, 0, 255, true, true )
+                surface.SetMaterial( gameMat2 )
+                surface.SetDrawColor( 255, 255, 255, 255 )
+
+                render.PushFilterMin( TEXFILTER.POINT )
+                surface.DrawTexturedRectUV( 0, 0, ScrW() * compressionMult, ScrH() * compressionMult, 0, 0, 1, 1 )
+                render.PopFilterMin()
+            render.SetRenderTarget()
+            cam.End2D()
+        end )
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawHUD", "Pixelate", function()
+            -- Make a stencil of all entities.
+            resetStencil()
+
+            render.SetStencilEnable( true )
+            render.SetStencilReferenceValue( 1 )
+            render.SetStencilCompareFunction( STENCIL_ALWAYS )
+            render.SetStencilPassOperation( STENCIL_REPLACE )
+
+            cam.Start3D()
+                for _, ent in ipairs( ents.GetAll() ) do
+                    if IsValid( ent ) and ent.DrawModel and not ent:IsEffectActive( EF_NODRAW ) and not BAD_CLASSES[ent:GetClass()] then
+                        ent:DrawModel()
+                    end
+                end
+            cam.End3D()
+
+            -- Draw the pixelated rt to the screen, respecting the stencil.
+            render.SetStencilCompareFunction( STENCIL_EQUAL )
+
+            cam.Start2D()
+                surface.SetMaterial( pixelMat )
+                surface.SetDrawColor( 255, 255, 255, 255 )
+
+                render.PushFilterMag( TEXFILTER.POINT )
+                surface.DrawTexturedRectUV( 0, 0, ScrW(), ScrH(), 0, 0, compressionMult, compressionMult )
+                render.PopFilterMag()
+            cam.End2D()
+
+            render.SetStencilEnable( false )
+        end )
+    end,
+
+    onEnd = function()
+        -- Do nothing.
+    end,
+
+    minDuration = 60,
+    maxDuration = 120,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = nil,
+    incompatibileEffects = {},
+    groups = {
+        "VisualOnly",
+        "ScreenOverlay",
+    },
+    incompatibleGroups = {
+        "ScreenOverlay",
+        "PP",
+    },
+} )

--- a/lua/cfc_ulx_commands/curse/effects/pixelated_ents.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated_ents.lua
@@ -57,7 +57,7 @@ CFCUlxCurse.RegisterEffect( {
             render.UpdateScreenEffectTexture()
 
             cam.Start2D()
-            render.SetRenderTarget( pixelRT )
+            render.PushRenderTarget( pixelRT, 0, 0, ScrW(), ScrH() )
                 render.Clear( 0, 0, 0, 255, true, true )
                 surface.SetMaterial( gameMat2 )
                 surface.SetDrawColor( 255, 255, 255, 255 )
@@ -65,7 +65,7 @@ CFCUlxCurse.RegisterEffect( {
                 render.PushFilterMin( TEXFILTER.POINT )
                 surface.DrawTexturedRectUV( 0, 0, ScrW() * compressionMult, ScrH() * compressionMult, 0, 0, 1, 1 )
                 render.PopFilterMin()
-            render.SetRenderTarget()
+            render.PopRenderTarget()
             cam.End2D()
         end )
 
@@ -90,7 +90,7 @@ CFCUlxCurse.RegisterEffect( {
             render.SetStencilCompareFunction( STENCIL_EQUAL )
 
             cam.Start2D()
-                surface.SetMaterial( pixelMat )
+                surface.SetMaterial( pixelMat, 0, 0, ScrW(), ScrH() )
                 surface.SetDrawColor( 255, 255, 255, 255 )
 
                 render.PushFilterMag( TEXFILTER.POINT )

--- a/lua/cfc_ulx_commands/curse/effects/pixelated_ents.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated_ents.lua
@@ -110,13 +110,15 @@ CFCUlxCurse.RegisterEffect( {
     maxDuration = 120,
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
-    incompatibileEffects = {},
+    incompatibileEffects = {
+        "Pixelated",
+    },
     groups = {
         "VisualOnly",
         "ScreenOverlay",
     },
     incompatibleGroups = {
-        "ScreenOverlay",
+        "HaltRenderScene",
         "PP",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/pixelated_ents.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated_ents.lua
@@ -12,16 +12,11 @@ local BAD_CLASSES = {
 }
 
 
-local gameMat2
+local gameMatIgnorez = CFCUlxCurse.IncludeEffectUtil( "common_materials" ).gameMatIgnorez
 local pixelRT
 local pixelMat
 
 if CLIENT then
-    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
-        ["$basetexture"] = "_rt_fullframefb",
-        ["$ignorez"] = 1,
-    } )
-
     pixelRT = GetRenderTarget( "cfc_ulx_commands_curse_pixelated_ents_rt", RT_SIZE, RT_SIZE )
 
     pixelMat = CreateMaterial( "cfc_ulx_commands_curse_pixelated_ents", "UnlitGeneric", {
@@ -59,7 +54,7 @@ CFCUlxCurse.RegisterEffect( {
             cam.Start2D()
             render.PushRenderTarget( pixelRT, 0, 0, ScrW(), ScrH() )
                 render.Clear( 0, 0, 0, 255, true, true )
-                surface.SetMaterial( gameMat2 )
+                surface.SetMaterial( gameMatIgnorez )
                 surface.SetDrawColor( 255, 255, 255, 255 )
 
                 render.PushFilterMin( TEXFILTER.POINT )

--- a/lua/cfc_ulx_commands/curse/effects/pixelated_ents.lua
+++ b/lua/cfc_ulx_commands/curse/effects/pixelated_ents.lua
@@ -85,7 +85,7 @@ CFCUlxCurse.RegisterEffect( {
             render.SetStencilCompareFunction( STENCIL_EQUAL )
 
             cam.Start2D()
-                surface.SetMaterial( pixelMat, 0, 0, ScrW(), ScrH() )
+                surface.SetMaterial( pixelMat )
                 surface.SetDrawColor( 255, 255, 255, 255 )
 
                 render.PushFilterMag( TEXFILTER.POINT )

--- a/lua/cfc_ulx_commands/curse/effects/resident_evil.lua
+++ b/lua/cfc_ulx_commands/curse/effects/resident_evil.lua
@@ -123,7 +123,7 @@ CFCUlxCurse.RegisterEffect( {
             }
 
             return view
-        end )
+        end, HOOK_HIGH )
 
         CFCUlxCurse.CreateEffectTimer( cursedPly, EFFECT_NAME, "CheckLineOfSight", LOS_DETECTION_INTERVAL, 0, function()
             local startPos = camPos

--- a/lua/cfc_ulx_commands/curse/effects/screen_mirror.lua
+++ b/lua/cfc_ulx_commands/curse/effects/screen_mirror.lua
@@ -1,11 +1,12 @@
 local EFFECT_NAME = "ScreenMirror"
 
 
-local gameMat
+local gameMat2
 
 if CLIENT then
-    gameMat = CreateMaterial( "cfc_ulx_commands_curse_game_rt", "UnlitGeneric", {
-        ["$basetexture"] = "_rt_PowerOfTwoFB"
+    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
+        ["$basetexture"] = "_rt_fullframefb",
+        ["$ignorez"] = 1,
     } )
 end
 
@@ -17,9 +18,11 @@ CFCUlxCurse.RegisterEffect( {
         if SERVER then return end
 
         CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawHUD", "LBozo", function()
+            render.UpdateScreenEffectTexture()
+
             cam.Start2D()
                 surface.SetDrawColor( 255, 255, 255, 255 )
-                surface.SetMaterial( gameMat )
+                surface.SetMaterial( gameMat2 )
 
                 surface.DrawTexturedRectUV( 0, 0, ScrW() / 2, ScrH(), 1, 0, 0.5, 1 )
             cam.End2D()
@@ -35,14 +38,13 @@ CFCUlxCurse.RegisterEffect( {
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
     incompatibileEffects = {
-        "ScreenScroll",
-        "MirrorWorld",
+        "MotionSight",
     },
     groups = {
         "VisualOnly",
         "ScreenOverlay",
     },
     incompatibleGroups = {
-        "ScreenOverlay",
+        "HaltRenderScene",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/screen_mirror.lua
+++ b/lua/cfc_ulx_commands/curse/effects/screen_mirror.lua
@@ -1,14 +1,7 @@
 local EFFECT_NAME = "ScreenMirror"
 
 
-local gameMat2
-
-if CLIENT then
-    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
-        ["$basetexture"] = "_rt_fullframefb",
-        ["$ignorez"] = 1,
-    } )
-end
+local gameMatIgnorez = CFCUlxCurse.IncludeEffectUtil( "common_materials" ).gameMatIgnorez
 
 
 CFCUlxCurse.RegisterEffect( {
@@ -22,7 +15,7 @@ CFCUlxCurse.RegisterEffect( {
 
             cam.Start2D()
                 surface.SetDrawColor( 255, 255, 255, 255 )
-                surface.SetMaterial( gameMat2 )
+                surface.SetMaterial( gameMatIgnorez )
 
                 surface.DrawTexturedRectUV( 0, 0, ScrW() / 2, ScrH(), 1, 0, 0.5, 1 )
             cam.End2D()

--- a/lua/cfc_ulx_commands/curse/effects/screen_mirror.lua
+++ b/lua/cfc_ulx_commands/curse/effects/screen_mirror.lua
@@ -16,11 +16,13 @@ CFCUlxCurse.RegisterEffect( {
     onStart = function( cursedPly )
         if SERVER then return end
 
-        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "HUDPaintBackground", "LBozo", function()
-            surface.SetDrawColor( 255, 255, 255, 255 )
-            surface.SetMaterial( gameMat )
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawHUD", "LBozo", function()
+            cam.Start2D()
+                surface.SetDrawColor( 255, 255, 255, 255 )
+                surface.SetMaterial( gameMat )
 
-            surface.DrawTexturedRectUV( 0, 0, ScrW() / 2, ScrH(), 1, 0, 0.5, 1 )
+                surface.DrawTexturedRectUV( 0, 0, ScrW() / 2, ScrH(), 1, 0, 0.5, 1 )
+            cam.End2D()
         end )
     end,
 

--- a/lua/cfc_ulx_commands/curse/effects/screen_scroll.lua
+++ b/lua/cfc_ulx_commands/curse/effects/screen_scroll.lua
@@ -3,14 +3,7 @@ local SPEED_MIN = 0.03
 local SPEED_MAX = 0.06
 
 
-local gameMat2
-
-if CLIENT then
-    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
-        ["$basetexture"] = "_rt_fullframefb",
-        ["$ignorez"] = 1,
-    } )
-end
+local gameMatIgnorez = CFCUlxCurse.IncludeEffectUtil( "common_materials" ).gameMatIgnorez
 
 
 
@@ -30,7 +23,7 @@ CFCUlxCurse.RegisterEffect( {
 
             cam.Start2D()
                 surface.SetDrawColor( 255, 255, 255, 255 )
-                surface.SetMaterial( gameMat2 )
+                surface.SetMaterial( gameMatIgnorez )
 
                 offset = ( offset + speed * FrameTime() ) % 1
 

--- a/lua/cfc_ulx_commands/curse/effects/screen_scroll.lua
+++ b/lua/cfc_ulx_commands/curse/effects/screen_scroll.lua
@@ -57,6 +57,7 @@ CFCUlxCurse.RegisterEffect( {
     excludeFromOnetime = true,
     incompatibileEffects = {
         "ScreenMirror",
+        "ScreenShuffle",
         "MirrorWorld",
     },
     groups = {

--- a/lua/cfc_ulx_commands/curse/effects/screen_scroll.lua
+++ b/lua/cfc_ulx_commands/curse/effects/screen_scroll.lua
@@ -3,13 +3,15 @@ local SPEED_MIN = 0.03
 local SPEED_MAX = 0.06
 
 
-local gameMat
+local gameMat2
 
 if CLIENT then
-    gameMat = CreateMaterial( "cfc_ulx_commands_curse_game_rt", "UnlitGeneric", {
-        ["$basetexture"] = "_rt_PowerOfTwoFB"
+    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
+        ["$basetexture"] = "_rt_fullframefb",
+        ["$ignorez"] = 1,
     } )
 end
+
 
 
 CFCUlxCurse.RegisterEffect( {
@@ -24,9 +26,11 @@ CFCUlxCurse.RegisterEffect( {
         speed = speed * ( math.random( 0, 1 ) == 0 and -1 or 1 )
 
         CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawHUD", "LBozo", function()
+            render.UpdateScreenEffectTexture()
+
             cam.Start2D()
                 surface.SetDrawColor( 255, 255, 255, 255 )
-                surface.SetMaterial( gameMat )
+                surface.SetMaterial( gameMat2 )
 
                 offset = ( offset + speed * FrameTime() ) % 1
 
@@ -58,15 +62,13 @@ CFCUlxCurse.RegisterEffect( {
     onetimeDurationMult = 1.5,
     excludeFromOnetime = true,
     incompatibileEffects = {
-        "ScreenMirror",
-        "ScreenShuffle",
-        "MirrorWorld",
+        "MotionSight",
     },
     groups = {
         "VisualOnly",
         "ScreenOverlay",
     },
     incompatibleGroups = {
-        "ScreenOverlay",
+        "HaltRenderScene",
     },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/screen_scroll.lua
+++ b/lua/cfc_ulx_commands/curse/effects/screen_scroll.lua
@@ -23,27 +23,29 @@ CFCUlxCurse.RegisterEffect( {
         local speed = math.Rand( SPEED_MIN, SPEED_MAX )
         speed = speed * ( math.random( 0, 1 ) == 0 and -1 or 1 )
 
-        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "HUDPaintBackground", "LBozo", function()
-            surface.SetDrawColor( 255, 255, 255, 255 )
-            surface.SetMaterial( gameMat )
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawHUD", "LBozo", function()
+            cam.Start2D()
+                surface.SetDrawColor( 255, 255, 255, 255 )
+                surface.SetMaterial( gameMat )
 
-            offset = ( offset + speed * FrameTime() ) % 1
+                offset = ( offset + speed * FrameTime() ) % 1
 
-            local w = ScrW()
-            local h = ScrH()
+                local w = ScrW()
+                local h = ScrH()
 
-            if mode == 1 then -- Horizontal
-                surface.DrawTexturedRect( w * ( 0 + offset ), 0, w, h )
-                surface.DrawTexturedRect( w * ( -1 + offset ), 0, w, h )
-            elseif mode == 2 then -- Vertical
-                surface.DrawTexturedRect( 0, h * ( 0 + offset ), w, h )
-                surface.DrawTexturedRect( 0, h * ( -1 + offset ), w, h )
-            else -- Diagonal
-                surface.DrawTexturedRect( w * ( 0 + offset ), h * ( 0 + offset ), w, h )
-                surface.DrawTexturedRect( w * ( -1 + offset ), h * ( 0 + offset ), w, h )
-                surface.DrawTexturedRect( w * ( -1 + offset ), h * ( -1 + offset ), w, h )
-                surface.DrawTexturedRect( w * ( 0 + offset ), h * ( -1 + offset ), w, h )
-            end
+                if mode == 1 then -- Horizontal
+                    surface.DrawTexturedRect( w * ( 0 + offset ), 0, w, h )
+                    surface.DrawTexturedRect( w * ( -1 + offset ), 0, w, h )
+                elseif mode == 2 then -- Vertical
+                    surface.DrawTexturedRect( 0, h * ( 0 + offset ), w, h )
+                    surface.DrawTexturedRect( 0, h * ( -1 + offset ), w, h )
+                else -- Diagonal
+                    surface.DrawTexturedRect( w * ( 0 + offset ), h * ( 0 + offset ), w, h )
+                    surface.DrawTexturedRect( w * ( -1 + offset ), h * ( 0 + offset ), w, h )
+                    surface.DrawTexturedRect( w * ( -1 + offset ), h * ( -1 + offset ), w, h )
+                    surface.DrawTexturedRect( w * ( 0 + offset ), h * ( -1 + offset ), w, h )
+                end
+            cam.End2D()
         end )
     end,
 

--- a/lua/cfc_ulx_commands/curse/effects/screen_shuffle.lua
+++ b/lua/cfc_ulx_commands/curse/effects/screen_shuffle.lua
@@ -73,7 +73,6 @@ CFCUlxCurse.RegisterEffect( {
 
         CFCUlxCurse.CreateEffectTimer( cursedPly, EFFECT_NAME, "Shuffle", shuffleInterval, 0, shuffleGrid )
 
-        --CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PostRenderVGUI", "Shuffle", function()
         CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawHUD", "Shuffle", function()
             render.UpdateScreenEffectTexture()
 

--- a/lua/cfc_ulx_commands/curse/effects/screen_shuffle.lua
+++ b/lua/cfc_ulx_commands/curse/effects/screen_shuffle.lua
@@ -107,15 +107,15 @@ CFCUlxCurse.RegisterEffect( {
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
     incompatibileEffects = {
-        -- Compatible with *some* ScreenOverlay effects, but not all.
-        "Lidar",
         "MotionSight",
         "Pixelated",
         --"PixelatedEnts", -- Scuffed as hell, but hilarious.
-        "ScreenScroll",
     },
     groups = {
         "VisualOnly",
+        "ScreenOverlay",
     },
-    incompatibleGroups = {},
+    incompatibleGroups = {
+        "HaltRenderScene",
+    },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/screen_shuffle.lua
+++ b/lua/cfc_ulx_commands/curse/effects/screen_shuffle.lua
@@ -5,14 +5,7 @@ local SHUFFLE_INTERVAL_MIN = 4
 local SHUFFLE_INTERVAL_MAX = 15
 
 
-local gameMat2
-
-if CLIENT then
-    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
-        ["$basetexture"] = "_rt_fullframefb",
-        ["$ignorez"] = 1,
-    } )
-end
+local gameMatIgnorez = CFCUlxCurse.IncludeEffectUtil( "common_materials" ).gameMatIgnorez
 
 
 CFCUlxCurse.RegisterEffect( {
@@ -77,7 +70,7 @@ CFCUlxCurse.RegisterEffect( {
             render.UpdateScreenEffectTexture()
 
             cam.Start2D()
-                surface.SetMaterial( gameMat2 )
+                surface.SetMaterial( gameMatIgnorez )
                 surface.SetDrawColor( 255, 255, 255, 255 )
 
                 for x = 1, gridSize do

--- a/lua/cfc_ulx_commands/curse/effects/screen_shuffle.lua
+++ b/lua/cfc_ulx_commands/curse/effects/screen_shuffle.lua
@@ -1,0 +1,122 @@
+local EFFECT_NAME = "ScreenShuffle"
+local GRID_SIZE_MIN = 2
+local GRID_SIZE_MAX = 5
+local SHUFFLE_INTERVAL_MIN = 4
+local SHUFFLE_INTERVAL_MAX = 15
+
+
+local gameMat2
+
+if CLIENT then
+    gameMat2 = CreateMaterial( "cfc_ulx_commands_curse_game_rt_2", "UnlitGeneric", {
+        ["$basetexture"] = "_rt_fullframefb",
+        ["$ignorez"] = 1,
+    } )
+end
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        if SERVER then return end
+
+        local scrW = ScrW()
+        local scrH = ScrH()
+        local gridSize = math.random( GRID_SIZE_MIN, GRID_SIZE_MAX )
+        local shuffleInterval = math.Rand( SHUFFLE_INTERVAL_MIN, SHUFFLE_INTERVAL_MAX )
+
+        local xStep = scrW / gridSize
+        local yStep = scrH / gridSize
+        local uvStep = 1 / gridSize
+        local gridXY = {}
+        local gridUV = {}
+
+        for x = 1, gridSize do
+            local xsXY = {}
+            local xsUV = {}
+            gridXY[x] = xsXY
+            gridUV[x] = xsUV
+
+            for y = 1, gridSize do
+                local u1 = x * uvStep
+                local v1 = y * uvStep
+
+                xsXY[y] = {
+                    x = ( x - 1 ) * xStep,
+                    y = ( y - 1 ) * yStep,
+                }
+
+                xsUV[y] = {
+                    u0 = u1 - uvStep,
+                    v0 = v1 - uvStep,
+                    v1 = v1,
+                    u1 = u1,
+                }
+            end
+        end
+
+
+        local function shuffleGrid()
+            for x1 = 1, gridSize do
+                for y1 = 1, gridSize do
+                    local x2 = math.random( 1, gridSize )
+                    local y2 = math.random( 1, gridSize )
+
+                    local temp = gridUV[x1][y1]
+                    gridUV[x1][y1] = gridUV[x2][y2]
+                    gridUV[x2][y2] = temp
+                end
+            end
+        end
+
+
+        CFCUlxCurse.CreateEffectTimer( cursedPly, EFFECT_NAME, "Shuffle", shuffleInterval, 0, shuffleGrid )
+
+        --CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PostRenderVGUI", "Shuffle", function()
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawHUD", "Shuffle", function()
+            render.UpdateScreenEffectTexture()
+
+            cam.Start2D()
+                surface.SetMaterial( gameMat2 )
+                surface.SetDrawColor( 255, 255, 255, 255 )
+
+                for x = 1, gridSize do
+                    local xsXY = gridXY[x]
+                    local xsUV = gridUV[x]
+
+                    for y = 1, gridSize do
+                        local xy = xsXY[y]
+                        local uv = xsUV[y]
+
+                        surface.DrawTexturedRectUV( xy.x, xy.y, xStep, yStep, uv.u0, uv.v0, uv.u1, uv.v1 )
+                    end
+                end
+            cam.End2D()
+        end )
+
+
+        shuffleGrid()
+    end,
+
+    onEnd = function()
+        -- Do nothing.
+    end,
+
+    minDuration = 60,
+    maxDuration = 120,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = nil,
+    incompatibileEffects = {
+        -- Compatible with *some* ScreenOverlay effects, but not all.
+        "Lidar",
+        "MotionSight",
+        "Pixelated",
+        --"PixelatedEnts", -- Scuffed as hell, but hilarious.
+        "ScreenScroll",
+    },
+    groups = {
+        "VisualOnly",
+    },
+    incompatibleGroups = {},
+} )

--- a/lua/cfc_ulx_commands/curse/effects/seeing_double.lua
+++ b/lua/cfc_ulx_commands/curse/effects/seeing_double.lua
@@ -1,0 +1,104 @@
+local EFFECT_NAME = "SeeingDouble"
+local DUPLICATE_INTERVAL = 0.05
+local DUPLICATE_CHANCE = 0.25
+local DUPLICATE_AMOUNT_MIN = 1
+local DUPLICATE_AMOUNT_MAX = 10
+
+
+local duplicates = {}
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        if SERVER then return end
+
+
+        CFCUlxCurse.CreateEffectTimer( cursedPly, EFFECT_NAME, "Duplicate", DUPLICATE_INTERVAL, 0, function()
+            if DUPLICATE_CHANCE ~= 1 and math.Rand( 0, 1 ) > DUPLICATE_CHANCE then return end
+
+            local props = ents.FindByClass( "prop_physics" )
+            local propCount = #props
+
+            if propCount == 0 then return end
+
+            local duplicateCount = #duplicates
+            local combinedCount = propCount + duplicateCount
+
+            for _ = 1, math.random( DUPLICATE_AMOUNT_MIN, DUPLICATE_AMOUNT_MAX ) do
+                local ind = math.random( 1, combinedCount )
+                local copyingADuplicate = ind > propCount
+                local entToCopy = copyingADuplicate and duplicates[ind - propCount] or props[ind]
+
+                if IsValid( entToCopy ) then
+                    local obbSize = entToCopy:OBBMaxs() - entToCopy:OBBMins()
+                    local pos = entToCopy:GetPos()
+                    local axisChoice = math.random( 1, 3 )
+                    local sign = math.random( 0, 1 ) == 0 and -1 or 1
+
+                    if axisChoise == 1 then
+                        pos = pos + entToCopy:GetForward() * sign * obbSize.x
+                    elseif axisChoice == 2 then
+                        pos = pos + entToCopy:GetRight() * sign * obbSize.y
+                    else
+                        pos = pos + entToCopy:GetUp() * sign * obbSize.z
+                    end
+
+                    local duplicate = ents.CreateClientProp( entToCopy:GetModel() )
+                    duplicate:SetModel( entToCopy:GetModel() )
+                    duplicate:SetPos( pos )
+                    duplicate:SetAngles( entToCopy:GetAngles() )
+                    duplicate:Spawn()
+                    duplicate:SetSkin( entToCopy:GetSkin() )
+                    duplicate:SetColor( entToCopy:GetColor() )
+                    duplicate:SetRenderMode( entToCopy:GetRenderMode() )
+                    duplicate:GetPhysicsObject():EnableMotion( false )
+
+                    for i = 0, entToCopy:GetNumBodyGroups() - 1 do
+                        duplicate:SetBodygroup( i, entToCopy:GetBodygroup( i ) )
+                    end
+
+                    for i = 0, #entToCopy:GetMaterials() - 1 do
+                        duplicate:SetSubMaterial( i, entToCopy:GetSubMaterial( i ) )
+                    end
+
+                    -- For some reason, :GetMaterial() doesn't work correctly on clientside props. :GetSubMaterial() and the rest do, though.
+                    local material = entToCopy.cfcUlxCurse_SeeingDouble_Material or entToCopy:GetMaterial()
+
+                    duplicate:SetMaterial( material )
+                    duplicate:SetParent( entToCopy:GetParent() )
+                    duplicate.cfcUlxCurse_SeeingDouble_Material = material
+
+                    table.insert( duplicates, duplicate )
+                elseif copyingADuplicate then
+                    table.remove( duplicates, ind - propCount )
+                end
+            end
+        end )
+    end,
+
+    onEnd = function()
+        if SERVER then return end
+
+        for i = #duplicates, 1, -1 do
+            local ent = duplicates[i]
+
+            if IsValid( ent ) then
+                ent:Remove()
+            end
+
+            duplicates[i] = nil
+        end
+    end,
+
+    minDuration = nil,
+    maxDuration = nil,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = nil,
+    incompatibileEffects = {},
+    groups = {
+        "VisualOnly",
+    },
+    incompatibleGroups = {},
+} )

--- a/lua/cfc_ulx_commands/curse/effects/sunbeams.lua
+++ b/lua/cfc_ulx_commands/curse/effects/sunbeams.lua
@@ -26,11 +26,11 @@ CFCUlxCurse.RegisterEffect( {
     maxDuration = 120,
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
-    incompatibileEffects = {
-        "Lidar",
-    },
+    incompatibileEffects = {},
     groups = {
         "VisualOnly",
     },
-    incompatibleGroups = {},
+    incompatibleGroups = {
+        "HaltRenderScene",
+    },
 } )

--- a/lua/cfc_ulx_commands/curse/effects/sunbeams.lua
+++ b/lua/cfc_ulx_commands/curse/effects/sunbeams.lua
@@ -1,0 +1,36 @@
+local EFFECT_NAME = "Sunbeams"
+local SUN_DARKEN = 0.8
+local SUN_MULT = 0.5
+local SUN_SIZE = 1
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        if SERVER then return end
+
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "PreDrawViewModels", "AverageDayInNewMexico", function()
+            cam.Start2D()
+                DrawSunbeams( SUN_DARKEN, SUN_MULT, SUN_SIZE, 0.5, 0.5 )
+            cam.End2D()
+        end )
+    end,
+
+    onEnd = function()
+        -- Do nothing.
+    end,
+
+    minDuration = 60,
+    maxDuration = 120,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = nil,
+    incompatibileEffects = {
+        "Lidar",
+    },
+    groups = {
+        "VisualOnly",
+    },
+    incompatibleGroups = {},
+} )

--- a/lua/cfc_ulx_commands/curse/effects/the_floor_is_lava.lua
+++ b/lua/cfc_ulx_commands/curse/effects/the_floor_is_lava.lua
@@ -40,6 +40,7 @@ CFCUlxCurse.RegisterEffect( {
         CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "Think", "Kill", function()
             if underGrace then return end
             if not cursedPly:Alive() then return end
+            if cursedPly.frozen then return end
             if cursedPly:WaterLevel() > 0 then return end
             if not cursedPly:OnGround() then return end
             if cursedPly:GetGroundEntity() ~= world then return end

--- a/lua/cfc_ulx_commands/curse/effects/the_mini_orb.lua
+++ b/lua/cfc_ulx_commands/curse/effects/the_mini_orb.lua
@@ -25,7 +25,7 @@ CFCUlxCurse.RegisterEffect( {
         theMiniOrb:Spawn()
         theMiniOrb:SetModelScale( 2 )
         theMiniOrb:Activate()
-        theMiniOrb:SetCollisionGroup( COLLISION_GROUP_DEBRIS_TRIGGER )
+        theMiniOrb:SetCollisionGroup( COLLISION_GROUP_WORLD )
         theMiniOrb:EmitSound( "ambient/energy/weld1.wav", 85, 90, 1, CHAN_AUTO )
         theMiniOrb:SetNWBool( "cfc_ulx_curse_is_the_mini_orb", true )
 

--- a/lua/cfc_ulx_commands/curse/effects/the_mini_orb.lua
+++ b/lua/cfc_ulx_commands/curse/effects/the_mini_orb.lua
@@ -23,8 +23,9 @@ CFCUlxCurse.RegisterEffect( {
         theMiniOrb:SetMaterial( "models/XQM//LightLinesRed" )
         theMiniOrb:SetPos( spawnPos )
         theMiniOrb:Spawn()
-        theMiniOrb:SetCollisionGroup( COLLISION_GROUP_IN_VEHICLE )
+        theMiniOrb:SetCollisionGroup( COLLISION_GROUP_DEBRIS_TRIGGER )
         theMiniOrb:EmitSound( "ambient/energy/weld1.wav", 85, 90, 1, CHAN_AUTO )
+        theMiniOrb:SetNWBool( "cfc_ulx_curse_is_the_mini_orb", true )
 
         local physObj = theMiniOrb:GetPhysicsObject()
         physObj:SetMass( 50000 )

--- a/lua/cfc_ulx_commands/curse/effects/the_mini_orb.lua
+++ b/lua/cfc_ulx_commands/curse/effects/the_mini_orb.lua
@@ -1,6 +1,6 @@
 local EFFECT_NAME = "TheMiniOrb" -- Not mini orb. The Mini Orb. Praise be The Orb.
 local SPEED_START = 10
-local SPEED_MAX = 350
+local SPEED_MAX = 300
 local SPEED_RATE = ( SPEED_MAX - SPEED_START ) / 10
 
 

--- a/lua/cfc_ulx_commands/curse/effects/the_mini_orb.lua
+++ b/lua/cfc_ulx_commands/curse/effects/the_mini_orb.lua
@@ -1,0 +1,114 @@
+local EFFECT_NAME = "TheMiniOrb" -- Not mini orb. The Mini Orb. Praise be The Orb.
+local SPEED_START = 10
+local SPEED_MAX = 350
+local SPEED_RATE = ( SPEED_MAX - SPEED_START ) / 10
+
+
+local ANGLE_ZERO = Angle( 0, 0, 0 )
+
+local orbsPerPly = {}
+
+
+CFCUlxCurse.RegisterEffect( {
+    name = EFFECT_NAME,
+
+    onStart = function( cursedPly )
+        if CLIENT then return end
+
+        local spawnPos = cursedPly:EyePos() + cursedPly:GetAngles():Forward() * 250
+        spawnPos = spawnPos + cursedPly:GetVelocity()
+
+        local theMiniOrb = ents.Create( "prop_physics" )
+        theMiniOrb:SetModel( "models/hunter/misc/sphere025x025.mdl" )
+        theMiniOrb:SetMaterial( "models/XQM//LightLinesRed" )
+        theMiniOrb:SetPos( spawnPos )
+        theMiniOrb:Spawn()
+        theMiniOrb:SetCollisionGroup( COLLISION_GROUP_IN_VEHICLE )
+        theMiniOrb:EmitSound( "ambient/energy/weld1.wav", 85, 90, 1, CHAN_AUTO )
+
+        local physObj = theMiniOrb:GetPhysicsObject()
+        physObj:SetMass( 50000 )
+        physObj:EnableMotion( false )
+
+        local speed = SPEED_START
+        local orbOBBMins = theMiniOrb:OBBMins()
+        local orbOBBMaxs = theMiniOrb:OBBMaxs()
+
+        orbsPerPly[cursedPly] = theMiniOrb
+
+        CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "Think", "Update", function()
+            if not IsValid( theMiniOrb ) then
+                CFCUlxCurse.StopCurseEffect( cursedPly, EFFECT_NAME )
+
+                return
+            end
+
+            if not cursedPly:Alive() then return end
+            if cursedPly.frozen then return end
+
+            local orbPos = theMiniOrb:GetPos()
+
+            if util.IsOBBIntersectingOBB( cursedPly:GetPos(), ANGLE_ZERO, cursedPly:OBBMins(), cursedPly:OBBMaxs(), orbPos, ANGLE_ZERO, orbOBBMins, orbOBBMaxs, 0 ) then
+                PrintMessage( HUD_PRINTCONSOLE, cursedPly:Nick() .. " got caught by The Mini Orb!" )
+                cursedPly:Kill()
+                theMiniOrb:EmitSound( "ambient/energy/newspark10.wav", 85, 85, 1, CHAN_AUTO )
+
+                return
+            end
+
+            local dt = FrameTime()
+
+            if speed < SPEED_MAX then
+                speed = speed + SPEED_RATE * dt
+            end
+
+            -- Just in case.
+            if physObj:IsMotionEnabled() then
+                physObj:EnableMotion( false )
+            end
+
+            local plyPos = cursedPly:GetPos() + cursedPly:OBBCenter()
+            local orbDir = ( plyPos - orbPos ):GetNormalized()
+
+            theMiniOrb:SetPos( orbPos + orbDir * speed * dt )
+        end )
+
+        theMiniOrb:CallOnRemove( "CFCUlxCurse_RemoveMiniOrbCurse", function()
+            if not IsValid( cursedPly ) then return end
+
+            CFCUlxCurse.StopCurseEffect( cursedPly, EFFECT_NAME )
+        end )
+
+
+        -- Weird stuff happens if you forcibly die while ragdolled.
+        if cursedPly.ragdoll then
+            ulx.unragdollPlayer( cursedPly )
+        end
+
+        ulx.setExclusive( cursedPly, "being chased by The Mini Orb" )
+    end,
+
+    onEnd = function( cursedPly )
+        if CLIENT then return end
+
+        local theMiniOrb = orbsPerPly[cursedPly]
+        orbsPerPly[cursedPly] = nil
+
+        if IsValid( theMiniOrb ) then
+            theMiniOrb:RemoveCallOnRemove( "CFCUlxCurse_RemoveMiniOrbCurse" )
+            theMiniOrb:Remove()
+        end
+
+        ulx.clearExclusive( cursedPly )
+    end,
+
+    minDuration = nil,
+    maxDuration = nil,
+    onetimeDurationMult = nil,
+    excludeFromOnetime = nil,
+    incompatibileEffects = {},
+    groups = {
+        "Death",
+    },
+    incompatibleGroups = {},
+} )

--- a/lua/cfc_ulx_commands/curse/effects/the_mini_orb.lua
+++ b/lua/cfc_ulx_commands/curse/effects/the_mini_orb.lua
@@ -23,6 +23,8 @@ CFCUlxCurse.RegisterEffect( {
         theMiniOrb:SetMaterial( "models/XQM//LightLinesRed" )
         theMiniOrb:SetPos( spawnPos )
         theMiniOrb:Spawn()
+        theMiniOrb:SetModelScale( 2 )
+        theMiniOrb:Activate()
         theMiniOrb:SetCollisionGroup( COLLISION_GROUP_DEBRIS_TRIGGER )
         theMiniOrb:EmitSound( "ambient/energy/weld1.wav", 85, 90, 1, CHAN_AUTO )
         theMiniOrb:SetNWBool( "cfc_ulx_curse_is_the_mini_orb", true )

--- a/lua/cfc_ulx_commands/curse/effects/top_down.lua
+++ b/lua/cfc_ulx_commands/curse/effects/top_down.lua
@@ -100,6 +100,8 @@ CFCUlxCurse.RegisterEffect( {
     onetimeDurationMult = nil,
     excludeFromOnetime = nil,
     incompatibileEffects = {
+        "Cyberspace",
+        "SuperCyberspace",
         "Isometric",
         "ResidentEvil",
     },

--- a/lua/cfc_ulx_commands/curse/effects/top_down.lua
+++ b/lua/cfc_ulx_commands/curse/effects/top_down.lua
@@ -64,7 +64,7 @@ CFCUlxCurse.RegisterEffect( {
                     bottom = scrHH * zoomFrac,
                 },
             }
-        end )
+        end, HOOK_HIGH )
 
         CFCUlxCurse.AddEffectHook( cursedPly, EFFECT_NAME, "Think", "Zoom", function()
             if orthoDistDir ~= 0 then

--- a/lua/cfc_ulx_commands/curse/effects/utils/common_materials.lua
+++ b/lua/cfc_ulx_commands/curse/effects/utils/common_materials.lua
@@ -1,0 +1,13 @@
+
+if SERVER then return {} end
+
+return {
+    gameMat = CreateMaterial( "cfc_ulx_commands_curse_game_rt", "UnlitGeneric", {
+        ["$basetexture"] = "_rt_fullframefb",
+    } ),
+
+    gameMatIgnorez = CreateMaterial( "cfc_ulx_commands_curse_game_rt_ignorez", "UnlitGeneric", {
+        ["$basetexture"] = "_rt_fullframefb",
+        ["$ignorez"] = 1,
+    } ),
+}

--- a/lua/cfc_ulx_commands/curse/effects/utils/common_materials.lua
+++ b/lua/cfc_ulx_commands/curse/effects/utils/common_materials.lua
@@ -10,4 +10,10 @@ return {
         ["$basetexture"] = "_rt_fullframefb",
         ["$ignorez"] = 1,
     } ),
+
+    gameMatVertexColor = CreateMaterial( "cfc_ulx_commands_curse_game_rt_vertex_color", "UnlitGeneric", {
+        ["$basetexture"] = "_rt_fullframefb",
+        ["$ignorez"] = 1,
+        ["$vertexcolor"] = 1,
+    } ),
 }

--- a/lua/cfc_ulx_commands/curse/effects/world_offset.lua
+++ b/lua/cfc_ulx_commands/curse/effects/world_offset.lua
@@ -52,5 +52,7 @@ CFCUlxCurse.RegisterEffect( {
     excludeFromOnetime = nil,
     incompatibileEffects = {},
     groups = {},
-    incompatibleGroups = {},
+    incompatibleGroups = {
+        "HaltRenderScene",
+    },
 } )

--- a/lua/cfc_ulx_commands/curse/sh_utils.lua
+++ b/lua/cfc_ulx_commands/curse/sh_utils.lua
@@ -19,7 +19,7 @@ CFCUlxCurse.EffectGroupIncompatibilities = {} -- lowercase curse name -> lookup 
 local effectNameToID = {}
 local onetimeEffectIDs = {}
 local effectHooks = {} -- Player -> { effectNameOne = { { hookName = string, listenerName = string, listenerNameEff = string }, ... }, effectNameTwo = ..., ... }
-local effectTimers = {} -- Player -> { effectNameOne = { string, ... }, effectNameTwo = ..., ... }
+local effectTimers = {} -- Player -> { effectNameOne = { { timerName = string, timerNameEff = string }, ... }, effectNameTwo = ..., ... }
 local includedEffectUtils = {}
 local getRandomCompatibleEffect
 local storeEffectIncompatibilities
@@ -392,10 +392,14 @@ function CFCUlxCurse.CreateEffectTimer( cursedPly, effectName, timerName, interv
         plyTimersByEffect[effectName] = plyTimers
     end
 
-    timerName = "CFC_ULXCommands_Curse_" .. effectName .. "_" .. timerName .. "_" .. cursedPly:SteamID64()
+    local timerNameEff = "CFC_ULXCommands_Curse_" .. effectName .. "_" .. timerName .. "_" .. cursedPly:SteamID64()
 
-    table.insert( plyTimers, timerName )
-    timer.Create( timerName, interval, repitions, func )
+    table.insert( plyTimers, {
+        timerName = timerName,
+        timerNameEff = timerNameEff,
+    } )
+
+    timer.Create( timerNameEff, interval, repitions, func )
 
     return timerName
 end
@@ -411,10 +415,10 @@ function CFCUlxCurse.RemoveEffectTimer( cursedPly, effectName, timerName )
     if not plyTimers then return end
 
     for i = #plyTimers, 1, -1 do
-        local plyTimer = plyTimers[i]
+        local timerData = plyTimers[i]
 
-        if plyTimer == timerName then
-            timer.Remove( timerName )
+        if timerData.timerName == timerName then
+            timer.Remove( timerData.timerNameEff )
             table.remove( plyTimers, i )
         end
     end
@@ -433,8 +437,8 @@ function CFCUlxCurse.RemoveEffectTimers( cursedPly, effectName )
     local plyTimers = plyTimersByEffect[effectName]
     if not plyTimers then return end
 
-    for _, plyTimer in ipairs( plyTimers ) do
-        timer.Remove( plyTimer )
+    for _, timerData in ipairs( plyTimers ) do
+        timer.Remove( timerData.timerNameEff )
     end
 
     plyTimersByEffect[effectName] = nil

--- a/lua/cfc_ulx_commands/curse/sh_utils.lua
+++ b/lua/cfc_ulx_commands/curse/sh_utils.lua
@@ -18,7 +18,7 @@ CFCUlxCurse.EffectGroupIncompatibilities = {} -- lowercase curse name -> lookup 
 
 local effectNameToID = {}
 local onetimeEffectIDs = {}
-local effectHooks = {} -- Player -> { effectNameOne = { { hookName = string, listenerName = string }, ... }, effectNameTwo = ..., ... }
+local effectHooks = {} -- Player -> { effectNameOne = { { hookName = string, listenerName = string, listenerNameEff = string }, ... }, effectNameTwo = ..., ... }
 local effectTimers = {} -- Player -> { effectNameOne = { string, ... }, effectNameTwo = ..., ... }
 local includedEffectUtils = {}
 local getRandomCompatibleEffect
@@ -319,14 +319,15 @@ function CFCUlxCurse.AddEffectHook( cursedPly, effectName, hookName, listenerNam
         plyHooksByEffect[effectName] = plyHooks
     end
 
-    listenerName = "CFC_ULXCommands_Curse_" .. effectName .. "_" .. listenerName .. "_" .. cursedPly:SteamID64()
+    local listenerNameEff = "CFC_ULXCommands_Curse_" .. effectName .. "_" .. listenerName .. "_" .. cursedPly:SteamID64()
 
     table.insert( plyHooks, {
         hookName = hookName,
         listenerName = listenerName,
+        listenerNameEff = listenerNameEff,
     } )
 
-    hook.Add( hookName, listenerName, func, priority )
+    hook.Add( hookName, listenerNameEff, func, priority )
 end
 
 -- Removes an effect's hook for a specific player.
@@ -343,7 +344,7 @@ function CFCUlxCurse.RemoveEffectHook( cursedPly, effectName, hookName, listener
         local hookData = plyHooks[i]
 
         if hookData.hookName == hookName and hookData.listenerName == listenerName then
-            hook.Remove( hookName, listenerName )
+            hook.Remove( hookName, hookData.listenerNameEff )
             table.remove( plyHooks, i )
         end
     end
@@ -363,7 +364,7 @@ function CFCUlxCurse.RemoveEffectHooks( cursedPly, effectName )
     if not plyHooks then return end
 
     for _, hookData in ipairs( plyHooks ) do
-        hook.Remove( hookData.hookName, hookData.listenerName )
+        hook.Remove( hookData.hookName, hookData.listenerNameEff )
     end
 
     plyHooksByEffect[effectName] = nil

--- a/lua/cfc_ulx_commands/curse/sh_utils.lua
+++ b/lua/cfc_ulx_commands/curse/sh_utils.lua
@@ -302,7 +302,7 @@ end
     - Adds an effect hook for a specific player.
     - For use only within the onStart() of effects.
 --]]
-function CFCUlxCurse.AddEffectHook( cursedPly, effectName, hookName, listenerName, func )
+function CFCUlxCurse.AddEffectHook( cursedPly, effectName, hookName, listenerName, func, priority )
     effectName = string.lower( effectName )
 
     local plyHooksByEffect = effectHooks[cursedPly]
@@ -326,7 +326,7 @@ function CFCUlxCurse.AddEffectHook( cursedPly, effectName, hookName, listenerNam
         listenerName = listenerName,
     } )
 
-    hook.Add( hookName, listenerName, func )
+    hook.Add( hookName, listenerName, func, priority )
 end
 
 -- Removes an effect's hook for a specific player.


### PR DESCRIPTION
Adds these effects:
- TheFloorIsLava
- TheMiniOrb
- SeeingDouble
- Cyberspace
- SuperCyberspace
- Pixelated
- PixelatedEnts
- ScreenShuffle
- Sunbeams
- MotionBlur
- DrunkBlur
- FilmDevelopment
- FilmDevelopmentNoClear
- ChromaticAberration
- ModelShuffle

Also makes these changes:
- Improves ScreenMirror and ScreenScroll to be compatible with more effects.
- Adds/removes incompatibility flags where needed, and consolidates some into more groups.
- Fixes `CFCUlxCurse.RemoveEffectHook()` and `CFCUlxCurse.CreateEffectTimer()` (note that the `-s` versions of these, used for curse cleanup, were already working fine)
- Moves commonly-used custom materials to the curse utils folder.
- Prevents addons from breaking calcview-related curses