### PR TITLE
add a hook to use from the autowarner

### DIFF
--- a/lua/autorun/server/cfc_auto_warn_on_commands.lua
+++ b/lua/autorun/server/cfc_auto_warn_on_commands.lua
@@ -117,8 +117,6 @@ function AW.warn( commandName, caller, target, reason )
     elseif awarn_warnplayerid then
         awarn_warnplayerid( caller, target, reason )
     end
-
-    hook.Run( "CFC_UlxCommands_AutoWarner", caller, target, reason )
 end
 
 function AW.getTargets( indices, args )

--- a/lua/autorun/server/cfc_auto_warn_on_commands.lua
+++ b/lua/autorun/server/cfc_auto_warn_on_commands.lua
@@ -117,6 +117,8 @@ function AW.warn( commandName, caller, target, reason )
     elseif awarn_warnplayerid then
         awarn_warnplayerid( caller, target, reason )
     end
+
+    hook.Run( "CFC_UlxCommands_AutoWarner", caller, target, reason )
 end
 
 function AW.getTargets( indices, args )

--- a/lua/autorun/server/cfc_auto_warn_on_commands.lua
+++ b/lua/autorun/server/cfc_auto_warn_on_commands.lua
@@ -95,13 +95,13 @@ function AW.warn( commandName, caller, target, reason )
     end
 
 
-
     local actorUID
     if IsValid( caller ) then
         actorUID = caller:SteamID64()
     else
         actorUID = "console"
     end
+
     if GMAudit then
         GMAudit.Public.CreateRecord( {
             type = commandName,
@@ -114,7 +114,7 @@ function AW.warn( commandName, caller, target, reason )
                 print( "Error creating GMAudit record: " .. err )
             end
         end )
-    else
+    elseif awarn_warnplayerid then
         awarn_warnplayerid( caller, target, reason )
     end
 end


### PR DESCRIPTION
By default if you kick/ban/etc the AutoWarner tries to use the awarn function, even if it doesnt exist. I just added a simple check.

Also added a hook that provides the caller, target, and reason so other warn addons could use it.