### PR TITLE
Fire hooks when timed punishments are applied or removed

### DIFF
--- a/lua/ulib/modules/timed_punishments.lua
+++ b/lua/ulib/modules/timed_punishments.lua
@@ -30,6 +30,7 @@ end
 
 function TP.Punish( steamID64, punishment, expiration, issuer, reason )
     Data:createPunishment( punishment, steamID64, expiration, issuer, reason )
+    hook.Run( "CFC_TimedPunishments_Punished", steamID64, punishment, expiration, issuer, reason )
 
     local ply = player.GetBySteamID64( steamID64 )
     if not IsValid( ply ) then return end
@@ -45,6 +46,7 @@ end
 
 function TP.Unpunish( steamID64, punishment )
     Data:removePunishment( punishment, steamID64 )
+    hook.Run( "CFC_TimedPunishments_Unpunished", steamID64, punishment )
 
     local ply = player.GetBySteamID64( steamID64 )
     if not IsValid( ply ) then return end


### PR DESCRIPTION
## Summary

- Fires `CFC_TimedPunishments_Punished` (steamID64, punishment, expiration, issuer, reason) in `TP.Punish` after writing to the local DB
- Fires `CFC_TimedPunishments_Unpunished` (steamID64, punishment) in `TP.Unpunish` after removing from the local DB

This allows external addons to react to timed punishment changes without patching this module. Specifically intended for gm_audit_glua integration.

## Test plan

- [ ] Apply a timed punishment to a player and verify `CFC_TimedPunishments_Punished` fires with correct args
- [ ] Remove a timed punishment and verify `CFC_TimedPunishments_Unpunished` fires
- [ ] Confirm existing punishment behaviour (enable/disable, DB writes) is unchanged